### PR TITLE
Add OIDC permissions for npm trusted publishing

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  id-token: write
+  contents: read
+
 concurrency:
   group: canary-publish
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Adds `id-token: write` and `contents: read` permissions to the canary publish workflow
- Required for npm trusted publishing via OIDC (provenance)