### PR TITLE
Update CI to actions v6 and Node 24

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -16,11 +16,11 @@ jobs:
   canary:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - run: npm ci


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4 to v6
- Update `actions/setup-node` from v4 to v6
- Update Node.js from 20 to 24