### PR TITLE
ci(lint): Add lint step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,5 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
       - run: pnpm build


### PR DESCRIPTION
## Description

- Add `pnpm lint` step to the CI workflow before the build step
- Depends on #22