### PR TITLE
ci(lint): Add lint as separate CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+
   build:
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

- Split lint into its own CI job so it appears as a separate check on GitHub PRs
- Lint and build now run in parallel