### PR TITLE
fix(types): Remove explicit `any` types from service and utils

### DIFF
--- a/projects/ngx-clerk/src/lib/services/clerk.service.ts
+++ b/projects/ngx-clerk/src/lib/services/clerk.service.ts
@@ -21,13 +21,14 @@ import { loadClerkScripts } from '../utils/loadClerkJsScript';
 import type { ClerkInitOptions } from '../utils/types';
 
 interface HeadlessBrowserClerk extends Clerk {
-  load: (opts?: Without<ClerkOptions, 'isSatellite'>) => Promise<void>;
+  load: (opts?: Without<ClerkOptions, 'isSatellite'> & Record<string, unknown>) => Promise<void>;
   updateClient: (client: ClientResource) => void;
+  __internal_updateProps: (props: Record<string, unknown>) => void;
 }
 
 interface BrowserClerk extends HeadlessBrowserClerk {
   onComponentsReady: Promise<void>;
-  components: any;
+  components: Record<string, unknown>;
 }
 
 declare global {
@@ -107,18 +108,20 @@ export class ClerkService {
         routerPush: (to: string) =>
           this._ngZone.run(() => {
             const url = new URL(to.replace('#/', ''), 'http://dummy.clerk');
-            const queryParams = Object.fromEntries((url.searchParams as any).entries());
+            const queryParams: Record<string, string> = {};
+            url.searchParams.forEach((v, k) => (queryParams[k] = v));
             return this._router.navigate([url.pathname], { queryParams });
           }),
         routerReplace: (to: string) =>
           this._ngZone.run(() => {
             const url = new URL(to.replace('#/', ''), 'http://dummy.clerk');
-            const queryParams = Object.fromEntries((url.searchParams as any).entries());
+            const queryParams: Record<string, string> = {};
+            url.searchParams.forEach((v, k) => (queryParams[k] = v));
             return this._router.navigate([url.pathname], { queryParams, replaceUrl: true });
           }),
         ...loadOptions,
         ui: { ClerkUI: clerkUICtorPromise },
-      } as any);
+      });
 
       this._ngZone.run(() => {
         this._client.set(window.Clerk.client ?? null);
@@ -146,7 +149,7 @@ export class ClerkService {
   updateAppearance(opts: ClerkOptions['appearance']) {
     const clerkInstance = this.clerk();
     if (clerkInstance) {
-      (clerkInstance as any).__internal_updateProps({ appearance: opts });
+      clerkInstance.__internal_updateProps({ appearance: opts });
     }
   }
 
@@ -154,7 +157,7 @@ export class ClerkService {
   updateLocalization(opts: ClerkOptions['localization']) {
     const clerkInstance = this.clerk();
     if (clerkInstance) {
-      (clerkInstance as any).__internal_updateProps({ localization: opts });
+      clerkInstance.__internal_updateProps({ localization: opts });
     }
   }
 

--- a/projects/ngx-clerk/src/lib/utils/loadClerkJsScript.ts
+++ b/projects/ngx-clerk/src/lib/utils/loadClerkJsScript.ts
@@ -2,11 +2,12 @@ import {
   loadClerkJSScript as loadClerkJSScriptShared,
   loadClerkUIScript as loadClerkUIScriptShared,
 } from '@clerk/shared/loadClerkJsScript';
+import type { ClerkUIConstructor } from '@clerk/shared/types';
 import type { ClerkInitOptions } from './types';
 
 declare global {
   interface Window {
-    __internal_ClerkUICtor: any;
+    __internal_ClerkUICtor: unknown;
   }
 }
 
@@ -16,7 +17,7 @@ const FAILED_TO_LOAD_ERROR = 'Clerk: Failed to load Clerk';
  * Loads ClerkJS and ClerkUI scripts in parallel.
  * Returns a promise for the ClerkUI constructor to be passed to Clerk.load().
  */
-export const loadClerkScripts = (opts: ClerkInitOptions): { clerkPromise: Promise<any>; clerkUICtorPromise: Promise<any> } => {
+export const loadClerkScripts = (opts: ClerkInitOptions): { clerkPromise: Promise<HTMLScriptElement | null>; clerkUICtorPromise: Promise<ClerkUIConstructor> } => {
   const { publishableKey } = opts;
 
   if (!publishableKey) {
@@ -45,7 +46,7 @@ export const loadClerkScripts = (opts: ClerkInitOptions): { clerkPromise: Promis
     if (!window.__internal_ClerkUICtor) {
       throw new Error('Failed to download latest Clerk UI. Contact support@clerk.com.');
     }
-    return window.__internal_ClerkUICtor;
+    return window.__internal_ClerkUICtor as ClerkUIConstructor;
   })();
 
   return { clerkPromise, clerkUICtorPromise };


### PR DESCRIPTION
## Description

- Replace all 9 `any` usages in `clerk.service.ts` and `loadClerkJsScript.ts` with proper types
- Add `__internal_updateProps` and widen `load` signature on `HeadlessBrowserClerk` interface
- Use `ClerkUIConstructor` import from `@clerk/shared/types` for proper script loader typing
- Replace `URLSearchParams` iteration with `forEach` to avoid needing `dom.iterable` lib