### PR TITLE
feat(ngx-clerk): Add Core 3 authentication parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,19 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
 
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -37,5 +50,4 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm lint
       - run: pnpm build

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # ngx-clerk
 
-Welcome to **ngx-clerk**, an unofficial Angular package that integrates with [Clerk](https://clerk.com/).
+**ngx-clerk** is an unofficial, community Angular SDK for [Clerk](https://clerk.com/) —
+drop-in components, a reactive service, structural directives, and route guards for
+authentication, user management, and organizations.
 
-### Disclaimer: This unofficial package is not affiliated with Clerk.com. It is an unofficial project that aims to provide a seamless integration of Clerk features into Angular applications.
+> **Disclaimer:** This is an unofficial, community-maintained package and is not affiliated
+> with Clerk.com.
 
 ## Prerequisites
 
 - Angular version **19 or higher**.
 - Clerk Core 3 (ClerkJS v6).
-- Currently, this package supports **client-side operations only**. Server-Side Rendering (SSR) is not supported at the moment.
+- Client-side operations only. Server-Side Rendering (SSR) is not supported at the moment.
 
 ## Installation
 
@@ -18,8 +21,8 @@ npm i ngx-clerk
 
 ## Getting Started
 
-1. Create an app in [Clerk Dashboard](https://dashboard.clerk.com/) and get the Publishable Key.
-2. **Add `provideClerk()` to your app config**:
+1. Create an app in the [Clerk Dashboard](https://dashboard.clerk.com/) and copy the Publishable Key.
+2. **Add `provideClerk()` to your app config:**
 
 ```typescript
 // app.config.ts
@@ -38,17 +41,15 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
-3. **Use Clerk components in your templates**:
+3. **Use Clerk components in your templates:**
 
 ```typescript
-// app.component.ts
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { ClerkUserButtonComponent } from 'ngx-clerk';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [RouterOutlet, ClerkUserButtonComponent],
   template: `
     <clerk-user-button />
@@ -67,15 +68,107 @@ import { canActivateClerk } from 'ngx-clerk';
 
 export const routes: Routes = [
   { path: '', component: HomeComponent },
+  { path: 'dashboard', component: DashboardComponent, canActivate: [canActivateClerk] },
+];
+```
+
+## UI Components
+
+All Clerk UI components are available and prefixed with `clerk-`. They accept the
+matching Clerk props via the `[props]` input, and update reactively when the input changes.
+
+| Component | Selector |
+| --- | --- |
+| Sign In | `<clerk-sign-in />` |
+| Sign Up | `<clerk-sign-up />` |
+| User Profile | `<clerk-user-profile />` |
+| User Button | `<clerk-user-button />` |
+| User Avatar | `<clerk-user-avatar />` |
+| Organization Profile | `<clerk-organization-profile />` |
+| Organization Switcher | `<clerk-organization-switcher />` |
+| Organization List | `<clerk-organization-list />` |
+| Create Organization | `<clerk-create-organization />` |
+| Waitlist | `<clerk-waitlist />` |
+| Pricing Table | `<clerk-pricing-table />` |
+| Google One Tap | `<clerk-google-one-tap />` |
+| OAuth/SSO callback | `<clerk-authenticate-with-redirect-callback />` |
+
+```html
+<clerk-sign-in [props]="{ routing: 'path', path: '/sign-in', signUpUrl: '/sign-up' }" />
+```
+
+## Control-flow directives
+
+Idiomatic Angular structural directives for conditionally rendering content based on
+auth state:
+
+```html
+<div *clerkLoading>Loading…</div>
+
+<ng-container *clerkLoaded>
+  <clerk-user-button *clerkSignedIn />
+  <button *clerkSignedOut clerkSignInButton>Sign in</button>
+</ng-container>
+```
+
+- `*clerkSignedIn` — renders when a user is signed in.
+- `*clerkSignedOut` — renders when Clerk is loaded and no user is signed in.
+- `*clerkLoaded` / `*clerkLoading` — renders based on whether Clerk has finished loading.
+
+## Authorization
+
+Gate UI by role, permission, feature, or plan with the `*clerkProtect` directive (with an
+optional `else` template), or check imperatively with `ClerkService.has()`:
+
+```html
+<section *clerkProtect="{ role: 'org:admin' }; else noAccess">Admins only</section>
+<ng-template #noAccess>You do not have access.</ng-template>
+```
+
+Protect a whole route with the `canActivateProtect` guard factory:
+
+```typescript
+import { canActivateProtect } from 'ngx-clerk';
+
+const routes: Routes = [
   {
-    path: 'dashboard',
-    component: DashboardComponent,
-    canActivate: [canActivateClerk],
+    path: 'admin',
+    component: AdminComponent,
+    canActivate: [canActivateProtect({ role: 'org:admin' }, { unauthorizedUrl: '/dashboard' })],
   },
 ];
 ```
 
-5. **Access auth state** via signals on `ClerkService`:
+## Buttons
+
+Attribute directives that trigger auth actions on your own button, with no extra DOM:
+
+```html
+<button clerkSignInButton>Sign in</button>
+<button clerkSignUpButton mode="modal">Create account</button>
+<button clerkSignOutButton redirectUrl="/">Sign out</button>
+```
+
+## Session tokens
+
+Fetch the current session JWT to authenticate your backend:
+
+```typescript
+const token = await clerk.getToken();
+```
+
+## ClerkService
+
+Central service exposing auth state as Angular signals plus imperative helpers.
+
+**Signals:** `clerk()`, `client()`, `session()`, `user()`, `organization()`, `isLoaded()`,
+`isSignedIn()`, `userId()`, `orgId()`, `sessionId()`, `orgRole()`, `orgSlug()`,
+`sessionClaims()`, `actor()`, `signIn()`, `signUp()`, `sessions()`, `membership()`.
+
+**Methods:** `has(params)`, `getToken(options?)`, `setActive(params)`,
+`handleRedirectCallback(params?)`, `signOut(options?)`, `openSignIn()` / `closeSignIn()`
+(and the other modal open/close helpers), `redirectToSignIn()` / `redirectToSignUp()`,
+`updateAppearance()`, `updateLocalization()`, `updateClerkOptions()`.
 
 ```typescript
 import { Component, inject } from '@angular/core';
@@ -94,33 +187,14 @@ export class DashboardComponent {
 }
 ```
 
-## Features
+## OAuth / SSO callback
 
-- **Clerk UI Components**: All Clerk UI components are available and prefixed with `clerk-`:
-    1. `<clerk-sign-in />`
-    2. `<clerk-sign-up />`
-    3. `<clerk-user-profile />`
-    4. `<clerk-user-button />`
-    5. `<clerk-organization-profile />`
-    6. `<clerk-organization-switcher />`
-    7. `<clerk-organization-list />`
-    8. `<clerk-create-organization />`
-    9. `<clerk-waitlist />`
-    10. `<clerk-user-avatar />`
-    11. `<clerk-pricing-table />`
+Place the callback component on your `/sso-callback` route to complete an OAuth redirect flow:
 
-- **ClerkService**: Central service exposing auth state as Angular signals:
-    - `user()` - Current `UserResource` or `null`
-    - `session()` - Current `ActiveSessionResource` or `null`
-    - `organization()` - Current `OrganizationResource` or `null`
-    - `client()` - Current `ClientResource` or `null`
-    - `clerk()` - The Clerk instance or `null`
-    - `isLoaded()` - Whether Clerk has finished loading
-    - `isSignedIn()` - Whether the user is signed in
-    - `userId()` - Current user ID or `null`
-    - `orgId()` - Current organization ID or `null`
-
-- **`canActivateClerk`**: A functional route guard that protects routes and waits for Clerk to load before checking auth state.
+```html
+<clerk-authenticate-with-redirect-callback
+  [props]="{ signInFallbackRedirectUrl: '/dashboard' }" />
+```
 
 ## Migrating from v0.x
 

--- a/angular.json
+++ b/angular.json
@@ -10,7 +10,7 @@
       "prefix": "lib",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:ng-packagr",
+          "builder": "@angular/build:ng-packagr",
           "options": {
             "project": "projects/ngx-clerk/ng-package.json"
           },
@@ -31,6 +31,14 @@
               "projects/ngx-clerk/**/*.ts",
               "projects/ngx-clerk/**/*.html"
             ]
+          }
+        },
+        "test": {
+          "builder": "@angular/build:unit-test",
+          "options": {
+            "tsConfig": "projects/ngx-clerk/tsconfig.spec.json",
+            "runner": "vitest",
+            "watch": false
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "ng build ngx-clerk && cp ./README.md ./dist/ngx-clerk/README.md",
     "watch": "ng build ngx-clerk --watch --configuration development",
     "lint": "ng lint",
+    "test": "ng test ngx-clerk",
     "release": "semantic-release",
     "prepare": "husky"
   },
@@ -53,10 +54,12 @@
     "angular-eslint": "^21.3.1",
     "eslint": "^10.2.0",
     "husky": "^9.1.7",
+    "jsdom": "^29.1.1",
     "ng-packagr": "^21.0.0",
     "semantic-release": "^25.0.3",
     "tailwindcss": "^4.2.2",
     "typescript": "~5.9.0",
-    "typescript-eslint": "^8.58.0"
+    "typescript-eslint": "^8.58.0",
+    "vitest": "^4.1.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: ^21.0.0
-        version: 21.2.6(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(@angular/compiler@21.2.7)(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(chokidar@5.0.0)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@21.2.2(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(tailwindcss@4.2.2)(tslib@2.8.1)(typescript@5.9.3))(tailwindcss@4.2.2)(typescript@5.9.3)
+        version: 21.2.6(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(@angular/compiler@21.2.7)(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(chokidar@5.0.0)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@21.2.2(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(tailwindcss@4.2.2)(tslib@2.8.1)(typescript@5.9.3))(tailwindcss@4.2.2)(typescript@5.9.3)(vitest@4.1.8(@types/node@25.5.2)(jsdom@29.1.1)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)))
       '@angular-eslint/eslint-plugin':
         specifier: ^21.3.1
         version: 21.3.1(@typescript-eslint/utils@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
@@ -62,7 +62,7 @@ importers:
         version: 21.3.1(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
       '@angular/build':
         specifier: ^21.2.6
-        version: 21.2.6(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(@angular/compiler@21.2.7)(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(chokidar@5.0.0)(jiti@2.6.1)(karma@6.4.4)(less@4.4.2)(ng-packagr@21.2.2(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(tailwindcss@4.2.2)(tslib@2.8.1)(typescript@5.9.3))(postcss@8.5.8)(tailwindcss@4.2.2)(terser@5.46.0)(tslib@2.8.1)(typescript@5.9.3)
+        version: 21.2.6(ad9e77849256c5dc8280bc78234454c1)
       '@angular/cli':
         specifier: ^21.0.0
         version: 21.2.6(@types/node@25.5.2)(chokidar@5.0.0)
@@ -99,6 +99,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       ng-packagr:
         specifier: ^21.0.0
         version: 21.2.2(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(tailwindcss@4.2.2)(tslib@2.8.1)(typescript@5.9.3)
@@ -114,6 +117,9 @@ importers:
       typescript-eslint:
         specifier: ^8.58.0
         version: 8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.5.2)(jsdom@29.1.1)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0))
 
 packages:
 
@@ -441,6 +447,21 @@ packages:
       '@angular/core': 21.2.7
       '@angular/platform-browser': 21.2.7
       rxjs: ^6.5.3 || ^7.4.0
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -947,6 +968,10 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@clerk/shared@4.4.0':
     resolution: {integrity: sha512-3iBX7Svp2XrSIgFk4VtyVq5OZsGStkMGqVfTBbbiFCbSKQ745OfM8j/c2wgpq5QdyavesoeDA6YiMWlpZM9/ng==}
     engines: {node: '>=20.9.0'}
@@ -1043,6 +1068,42 @@ packages:
         optional: true
       conventional-commits-parser:
         optional: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.7':
+    resolution: {integrity: sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5':
+    resolution: {integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@discoveryjs/json-ext@0.6.3':
     resolution: {integrity: sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==}
@@ -1407,6 +1468,15 @@ packages:
   '@eslint/plugin-kit@0.7.0':
     resolution: {integrity: sha512-ejvBr8MQCbVsWNZnCwDXjUKq40MDmHalq7cJ6e9s/qzTUFIIo/afzt1Vui9T97FM/V/pN4YsFVoed5NIa96RDg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@gar/promise-retry@1.0.3':
     resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
@@ -2717,6 +2787,9 @@ packages:
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect-history-api-fallback@1.5.4':
     resolution: {integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==}
 
@@ -2725,6 +2798,9 @@ packages:
 
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -2853,6 +2929,35 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     peerDependencies:
       vite: '>=7.3.2'
+
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: '>=7.3.2'
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -3051,6 +3156,10 @@ packages:
     resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
     engines: {node: '>=12.0.0'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   autoprefixer@10.4.27:
     resolution: {integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3114,6 +3223,9 @@ packages:
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
@@ -3188,6 +3300,10 @@ packages:
 
   caniuse-lite@1.0.30001785:
     resolution: {integrity: sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -3445,6 +3561,10 @@ packages:
   css-select@6.0.0:
     resolution: {integrity: sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css-what@7.0.0:
     resolution: {integrity: sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==}
     engines: {node: '>= 6'}
@@ -3456,6 +3576,10 @@ packages:
 
   custom-event@1.0.1:
     resolution: {integrity: sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   date-format@4.0.14:
     resolution: {integrity: sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==}
@@ -3477,6 +3601,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -3617,6 +3744,10 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   env-ci@11.2.0:
     resolution: {integrity: sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA==}
     engines: {node: ^18.17 || >=20.6.1}
@@ -3737,6 +3868,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -3774,6 +3908,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -4069,6 +4207,10 @@ packages:
   hpack.js@2.1.6:
     resolution: {integrity: sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
@@ -4310,6 +4452,9 @@ packages:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -4399,6 +4544,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -4674,6 +4828,10 @@ packages:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
     engines: {node: 20 || >=22}
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -4706,6 +4864,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -5080,6 +5241,10 @@ packages:
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -5229,6 +5394,9 @@ packages:
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -5269,6 +5437,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -5637,6 +5808,10 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
@@ -5728,6 +5903,9 @@ packages:
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -5835,6 +6013,9 @@ packages:
     resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -5845,6 +6026,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stdin-discarder@0.3.1:
     resolution: {integrity: sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==}
@@ -5931,6 +6115,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
@@ -5998,6 +6185,9 @@ packages:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
@@ -6005,6 +6195,17 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.2:
+    resolution: {integrity: sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==}
+
+  tldts@7.4.2:
+    resolution: {integrity: sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==}
+    hasBin: true
 
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
@@ -6017,6 +6218,14 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   traverse@0.6.8:
     resolution: {integrity: sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==}
@@ -6117,6 +6326,10 @@ packages:
 
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.27.2:
+    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -6248,9 +6461,54 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: '>=7.3.2'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@2.0.1:
     resolution: {integrity: sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==}
     engines: {node: '>=0.10.0'}
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
 
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
@@ -6264,6 +6522,10 @@ packages:
 
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
 
   webpack-dev-middleware@7.4.5:
     resolution: {integrity: sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==}
@@ -6323,6 +6585,14 @@ packages:
     resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
     engines: {node: '>=0.8.0'}
 
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -6331,6 +6601,11 @@ packages:
   which@6.0.1:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wildcard@2.0.1:
@@ -6389,6 +6664,13 @@ packages:
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -6571,13 +6853,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@21.2.6(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(@angular/compiler@21.2.7)(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(chokidar@5.0.0)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@21.2.2(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(tailwindcss@4.2.2)(tslib@2.8.1)(typescript@5.9.3))(tailwindcss@4.2.2)(typescript@5.9.3)':
+  '@angular-devkit/build-angular@21.2.6(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(@angular/compiler@21.2.7)(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(chokidar@5.0.0)(jiti@2.6.1)(karma@6.4.4)(ng-packagr@21.2.2(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(tailwindcss@4.2.2)(tslib@2.8.1)(typescript@5.9.3))(tailwindcss@4.2.2)(typescript@5.9.3)(vitest@4.1.8(@types/node@25.5.2)(jsdom@29.1.1)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.6(chokidar@5.0.0)
       '@angular-devkit/build-webpack': 0.2102.6(chokidar@5.0.0)(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.105.2(esbuild@0.27.3)))(webpack@5.105.2(esbuild@0.27.3))
       '@angular-devkit/core': 21.2.6(chokidar@5.0.0)
-      '@angular/build': 21.2.6(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(@angular/compiler@21.2.7)(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(chokidar@5.0.0)(jiti@2.6.1)(karma@6.4.4)(less@4.4.2)(ng-packagr@21.2.2(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(tailwindcss@4.2.2)(tslib@2.8.1)(typescript@5.9.3))(postcss@8.5.6)(tailwindcss@4.2.2)(terser@5.46.0)(tslib@2.8.1)(typescript@5.9.3)
+      '@angular/build': 21.2.6(44698fd7ad8541420a133fdc15002881)
       '@angular/compiler-cli': 21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3)
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -6761,7 +7043,7 @@ snapshots:
       '@angular/core': 21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)
       tslib: 2.8.1
 
-  '@angular/build@21.2.6(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(@angular/compiler@21.2.7)(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(chokidar@5.0.0)(jiti@2.6.1)(karma@6.4.4)(less@4.4.2)(ng-packagr@21.2.2(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(tailwindcss@4.2.2)(tslib@2.8.1)(typescript@5.9.3))(postcss@8.5.6)(tailwindcss@4.2.2)(terser@5.46.0)(tslib@2.8.1)(typescript@5.9.3)':
+  '@angular/build@21.2.6(44698fd7ad8541420a133fdc15002881)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.6(chokidar@5.0.0)
@@ -6803,6 +7085,7 @@ snapshots:
       ng-packagr: 21.2.2(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(tailwindcss@4.2.2)(tslib@2.8.1)(typescript@5.9.3)
       postcss: 8.5.6
       tailwindcss: 4.2.2
+      vitest: 4.1.8(@types/node@25.5.2)(jsdom@29.1.1)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0))
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -6818,7 +7101,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.2.6(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(@angular/compiler@21.2.7)(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(chokidar@5.0.0)(jiti@2.6.1)(karma@6.4.4)(less@4.4.2)(ng-packagr@21.2.2(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(tailwindcss@4.2.2)(tslib@2.8.1)(typescript@5.9.3))(postcss@8.5.8)(tailwindcss@4.2.2)(terser@5.46.0)(tslib@2.8.1)(typescript@5.9.3)':
+  '@angular/build@21.2.6(ad9e77849256c5dc8280bc78234454c1)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.6(chokidar@5.0.0)
@@ -6860,6 +7143,7 @@ snapshots:
       ng-packagr: 21.2.2(@angular/compiler-cli@21.2.7(@angular/compiler@21.2.7)(typescript@5.9.3))(tailwindcss@4.2.2)(tslib@2.8.1)(typescript@5.9.3)
       postcss: 8.5.8
       tailwindcss: 4.2.2
+      vitest: 4.1.8(@types/node@25.5.2)(jsdom@29.1.1)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0))
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -6967,6 +7251,26 @@ snapshots:
       '@angular/platform-browser': 21.2.7(@angular/animations@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.7(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.7(@angular/compiler@21.2.7)(rxjs@7.8.2)(zone.js@0.16.1))
       rxjs: 7.8.2
       tslib: 2.8.1
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.7(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -7638,6 +7942,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@clerk/shared@4.4.0':
     dependencies:
       '@tanstack/query-core': 5.90.16
@@ -7771,6 +8079,30 @@ snapshots:
     optionalDependencies:
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.4.0
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.7(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@discoveryjs/json-ext@0.6.3': {}
 
@@ -7979,6 +8311,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@gar/promise-retry@1.0.3': {}
 
@@ -9177,6 +9511,11 @@ snapshots:
     dependencies:
       '@types/node': 25.5.2
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 4.19.8
@@ -9190,6 +9529,8 @@ snapshots:
     dependencies:
       '@types/node': 25.5.2
     optional: true
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -9362,6 +9703,47 @@ snapshots:
   '@vitejs/plugin-basic-ssl@2.1.4(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0))':
     dependencies:
       vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)
+
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -9592,6 +9974,8 @@ snapshots:
       pvutils: 1.1.5
       tslib: 2.8.1
 
+  assertion-error@2.0.1: {}
+
   autoprefixer@10.4.27(postcss@8.5.6):
     dependencies:
       browserslist: 4.28.2
@@ -9666,6 +10050,10 @@ snapshots:
       postcss-safe-parser: 7.0.1(postcss@8.5.8)
 
   before-after-hook@4.0.0: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   big.js@5.2.2: {}
 
@@ -9769,6 +10157,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001785: {}
+
+  chai@6.2.2: {}
 
   chalk@2.4.2:
     dependencies:
@@ -10048,12 +10438,24 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css-what@7.0.0: {}
 
   cssesc@3.0.0: {}
 
   custom-event@1.0.1:
     optional: true
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   date-format@4.0.14:
     optional: true
@@ -10065,6 +10467,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-extend@0.6.0: {}
 
@@ -10200,6 +10604,8 @@ snapshots:
   entities@6.0.1: {}
 
   entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   env-ci@11.2.0:
     dependencies:
@@ -10374,6 +10780,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -10428,6 +10838,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -10791,6 +11203,12 @@ snapshots:
       readable-stream: 2.3.8
       wbuf: 1.7.3
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   htmlparser2@10.1.0:
     dependencies:
       domelementtype: 2.3.0
@@ -11003,6 +11421,8 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-regex@1.2.1:
@@ -11079,6 +11499,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.27.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -11369,6 +11815,8 @@ snapshots:
 
   lru-cache@11.2.7: {}
 
+  lru-cache@11.5.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -11420,6 +11868,8 @@ snapshots:
   marked@15.0.12: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   media-typer@0.3.0: {}
 
@@ -11748,6 +12198,8 @@ snapshots:
 
   obuf@1.1.2: {}
 
+  obug@2.1.3: {}
+
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -11928,6 +12380,10 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   parseurl@1.3.3: {}
 
   path-exists@3.0.0: {}
@@ -11953,6 +12409,8 @@ snapshots:
   path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -12382,6 +12840,10 @@ snapshots:
   sax@1.6.0:
     optional: true
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
@@ -12547,6 +13009,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -12703,11 +13167,15 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  stackback@0.0.2: {}
+
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  std-env@4.1.0: {}
 
   stdin-discarder@0.3.1: {}
 
@@ -12795,6 +13263,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tagged-tag@1.0.0: {}
 
   tailwindcss@4.2.2: {}
@@ -12858,12 +13328,22 @@ snapshots:
     dependencies:
       convert-hrtime: 5.0.0
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.4.2: {}
+
+  tldts@7.4.2:
+    dependencies:
+      tldts-core: 7.4.2
 
   tmp@0.2.5:
     optional: true
@@ -12873,6 +13353,14 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.2
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   traverse@0.6.8: {}
 
@@ -12956,6 +13444,8 @@ snapshots:
 
   undici@7.24.4: {}
 
+  undici@7.27.2: {}
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
@@ -13034,8 +13524,40 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  vitest@4.1.8(@types/node@25.5.2)(jsdom@29.1.1)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.2
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
   void-elements@2.0.1:
     optional: true
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   watchpack@2.5.1:
     dependencies:
@@ -13050,6 +13572,8 @@ snapshots:
     optional: true
 
   web-worker@1.5.0: {}
+
+  webidl-conversions@8.0.1: {}
 
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.105.2(esbuild@0.27.3)):
     dependencies:
@@ -13156,6 +13680,16 @@ snapshots:
 
   websocket-extensions@0.1.4: {}
 
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -13163,6 +13697,11 @@ snapshots:
   which@6.0.1:
     dependencies:
       isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wildcard@2.0.1: {}
 
@@ -13203,6 +13742,10 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 

--- a/projects/demo/src/app/app.routes.ts
+++ b/projects/demo/src/app/app.routes.ts
@@ -1,5 +1,5 @@
 import { Routes } from '@angular/router';
-import { canActivateClerk, catchAllRoute } from 'ngx-clerk';
+import { canActivateClerk, canActivateProtect, catchAllRoute } from 'ngx-clerk';
 
 export const routes: Routes = [
   {
@@ -13,6 +13,14 @@ export const routes: Routes = [
   {
     matcher: catchAllRoute('sign-up'),
     loadComponent: () => import('./pages/sign-up.component').then(m => m.SignUpComponent),
+  },
+  {
+    path: 'waitlist',
+    loadComponent: () => import('./pages/waitlist.component').then(m => m.WaitlistComponent),
+  },
+  {
+    path: 'sso-callback',
+    loadComponent: () => import('./pages/sso-callback.component').then(m => m.SsoCallbackComponent),
   },
   {
     path: 'dashboard',
@@ -38,6 +46,27 @@ export const routes: Routes = [
       {
         path: 'organization-list',
         loadComponent: () => import('./pages/dashboard/org-list.component').then(m => m.OrgListPageComponent),
+      },
+      {
+        path: 'sessions',
+        loadComponent: () => import('./pages/dashboard/sessions.component').then(m => m.SessionsPageComponent),
+      },
+      {
+        path: 'session-token',
+        loadComponent: () => import('./pages/dashboard/session-token.component').then(m => m.SessionTokenPageComponent),
+      },
+      {
+        path: 'protect',
+        loadComponent: () => import('./pages/dashboard/protect.component').then(m => m.ProtectPageComponent),
+      },
+      {
+        path: 'billing',
+        loadComponent: () => import('./pages/dashboard/billing.component').then(m => m.BillingPageComponent),
+      },
+      {
+        path: 'admin',
+        canActivate: [canActivateProtect({ role: 'org:admin' }, { unauthorizedUrl: '/dashboard' })],
+        loadComponent: () => import('./pages/dashboard/admin.component').then(m => m.AdminPageComponent),
       },
     ],
   },

--- a/projects/demo/src/app/components/sidebar.component.ts
+++ b/projects/demo/src/app/components/sidebar.component.ts
@@ -1,10 +1,10 @@
 import { Component, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
-import { ClerkService, ClerkUserButtonComponent } from 'ngx-clerk';
+import { ClerkService, ClerkSignOutButtonDirective, ClerkUserButtonComponent } from 'ngx-clerk';
 
 @Component({
   selector: 'app-sidebar',
-  imports: [RouterLink, RouterLinkActive, ClerkUserButtonComponent],
+  imports: [RouterLink, RouterLinkActive, ClerkUserButtonComponent, ClerkSignOutButtonDirective],
   template: `
     <aside class="fixed left-0 top-0 h-screen w-60 bg-dark-surface flex flex-col border-r border-dark-border">
       <!-- Logo -->
@@ -14,65 +14,23 @@ import { ClerkService, ClerkUserButtonComponent } from 'ngx-clerk';
 
       <!-- Navigation -->
       <nav class="flex-1 px-3 py-4 space-y-1 overflow-y-auto">
-        <a
-          routerLink="/dashboard"
-          routerLinkActive="bg-white/10 text-white"
-          [routerLinkActiveOptions]="{ exact: true }"
-          class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-400 hover:text-white hover:bg-white/5 transition-colors"
-        >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1" />
-          </svg>
-          Dashboard
-        </a>
-
-        <a
-          routerLink="/dashboard/user-profile"
-          routerLinkActive="bg-white/10 text-white"
-          class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-400 hover:text-white hover:bg-white/5 transition-colors"
-        >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-          </svg>
-          User Profile
-        </a>
-
-        <a
-          routerLink="/dashboard/organization-profile"
-          routerLinkActive="bg-white/10 text-white"
-          class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-400 hover:text-white hover:bg-white/5 transition-colors"
-        >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
-          </svg>
-          Organization
-        </a>
-
-        <a
-          routerLink="/dashboard/create-organization"
-          routerLinkActive="bg-white/10 text-white"
-          class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-400 hover:text-white hover:bg-white/5 transition-colors"
-        >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 4v16m8-8H4" />
-          </svg>
-          Create Organization
-        </a>
-
-        <a
-          routerLink="/dashboard/organization-list"
-          routerLinkActive="bg-white/10 text-white"
-          class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-400 hover:text-white hover:bg-white/5 transition-colors"
-        >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
-          </svg>
-          Organization List
-        </a>
+        @for (item of navItems; track item.path) {
+          <a
+            [routerLink]="item.path"
+            routerLinkActive="bg-white/10 text-white"
+            [routerLinkActiveOptions]="{ exact: item.exact }"
+            class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-400 hover:text-white hover:bg-white/5 transition-colors"
+          >
+            <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" [attr.d]="item.icon" />
+            </svg>
+            {{ item.label }}
+          </a>
+        }
       </nav>
 
-      <!-- User button at bottom -->
-      <div class="px-4 py-4 border-t border-dark-border">
+      <!-- User button + sign out at bottom -->
+      <div class="px-4 py-4 border-t border-dark-border space-y-3">
         <div class="flex items-center gap-3">
           <clerk-user-button />
           @if (clerk.user(); as user) {
@@ -82,10 +40,30 @@ import { ClerkService, ClerkUserButtonComponent } from 'ngx-clerk';
             </div>
           }
         </div>
+        <button
+          clerkSignOutButton
+          redirectUrl="/"
+          class="w-full text-sm px-3 py-2 rounded-lg border border-dark-border text-gray-300 hover:text-white hover:bg-white/5 transition-colors"
+        >
+          Sign out
+        </button>
       </div>
     </aside>
   `,
 })
 export class SidebarComponent {
-  clerk = inject(ClerkService);
+  readonly clerk = inject(ClerkService);
+
+  readonly navItems = [
+    { path: '/dashboard', exact: true, label: 'Dashboard', icon: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1' },
+    { path: '/dashboard/user-profile', exact: false, label: 'User Profile', icon: 'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z' },
+    { path: '/dashboard/organization-profile', exact: false, label: 'Organization', icon: 'M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4' },
+    { path: '/dashboard/create-organization', exact: false, label: 'Create Organization', icon: 'M12 4v16m8-8H4' },
+    { path: '/dashboard/organization-list', exact: false, label: 'Organization List', icon: 'M4 6h16M4 10h16M4 14h16M4 18h16' },
+    { path: '/dashboard/sessions', exact: false, label: 'Active Sessions', icon: 'M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z' },
+    { path: '/dashboard/session-token', exact: false, label: 'Session Token', icon: 'M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z' },
+    { path: '/dashboard/protect', exact: false, label: 'Authorization', icon: 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z' },
+    { path: '/dashboard/billing', exact: false, label: 'Billing', icon: 'M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z' },
+    { path: '/dashboard/admin', exact: false, label: 'Admin', icon: 'M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z' },
+  ];
 }

--- a/projects/demo/src/app/pages/dashboard/admin.component.ts
+++ b/projects/demo/src/app/pages/dashboard/admin.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-admin-page',
+  imports: [RouterLink],
+  template: `
+    <div class="p-8 max-w-3xl">
+      <div class="mb-6">
+        <h1 class="text-2xl font-bold text-gray-900">Admin area</h1>
+        <p class="mt-1 text-gray-500">
+          This route is protected by <code>canActivateProtect(&#123; role: 'org:admin' &#125;)</code>.
+        </p>
+      </div>
+      <div class="rounded-xl border border-gray-200 bg-white p-6 text-sm text-gray-700">
+        You can only see this page because you hold the <code>org:admin</code> role in the active organization.
+        Otherwise the guard would have redirected you back to the
+        <a routerLink="/dashboard" class="text-primary hover:underline">dashboard</a>.
+      </div>
+    </div>
+  `,
+})
+export class AdminPageComponent {}

--- a/projects/demo/src/app/pages/dashboard/billing.component.ts
+++ b/projects/demo/src/app/pages/dashboard/billing.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { ClerkPricingTableComponent } from 'ngx-clerk';
+
+@Component({
+  selector: 'app-billing-page',
+  imports: [ClerkPricingTableComponent],
+  template: `
+    <div class="p-8">
+      <div class="mb-6">
+        <h1 class="text-2xl font-bold text-gray-900">Billing</h1>
+        <p class="mt-1 text-gray-500">Clerk's <code>&lt;clerk-pricing-table /&gt;</code> rendered with your configured plans.</p>
+      </div>
+      <div class="rounded-xl border border-gray-200 bg-white p-6">
+        <clerk-pricing-table />
+      </div>
+    </div>
+  `,
+})
+export class BillingPageComponent {}

--- a/projects/demo/src/app/pages/dashboard/protect.component.ts
+++ b/projects/demo/src/app/pages/dashboard/protect.component.ts
@@ -1,0 +1,45 @@
+import { Component, inject } from '@angular/core';
+import { ClerkProtectDirective, ClerkService } from 'ngx-clerk';
+
+@Component({
+  selector: 'app-protect-page',
+  imports: [ClerkProtectDirective],
+  template: `
+    <div class="p-8 max-w-3xl">
+      <div class="mb-6">
+        <h1 class="text-2xl font-bold text-gray-900">Authorization</h1>
+        <p class="mt-1 text-gray-500">
+          Gate UI with the <code>*clerkProtect</code> directive and <code>ClerkService.has()</code>.
+        </p>
+      </div>
+
+      <div class="space-y-4">
+        <div class="rounded-xl border border-gray-200 bg-white p-6">
+          <h3 class="font-semibold text-gray-900 mb-3">Admins only</h3>
+          <div
+            *clerkProtect="{ role: 'org:admin' }; else notAdmin"
+            class="text-sm text-green-700 bg-green-50 rounded-lg px-3 py-2"
+          >
+            ✓ You have the <code>org:admin</code> role in the active organization.
+          </div>
+          <ng-template #notAdmin>
+            <div class="text-sm text-gray-600 bg-gray-50 rounded-lg px-3 py-2">
+              You need the <code>org:admin</code> role to see this content.
+            </div>
+          </ng-template>
+        </div>
+
+        <div class="rounded-xl border border-gray-200 bg-white p-6">
+          <h3 class="font-semibold text-gray-900 mb-2">Imperative check</h3>
+          <p class="text-sm text-gray-600">
+            <code>has(&#123; permission: 'org:posts:manage' &#125;)</code> →
+            <span class="font-mono font-medium">{{ clerk.has({ permission: 'org:posts:manage' }) }}</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class ProtectPageComponent {
+  readonly clerk = inject(ClerkService);
+}

--- a/projects/demo/src/app/pages/dashboard/session-token.component.ts
+++ b/projects/demo/src/app/pages/dashboard/session-token.component.ts
@@ -1,0 +1,56 @@
+import { Component, inject, signal } from '@angular/core';
+import { ClerkService } from 'ngx-clerk';
+
+@Component({
+  selector: 'app-session-token-page',
+  template: `
+    <div class="p-8 max-w-3xl">
+      <div class="mb-6">
+        <h1 class="text-2xl font-bold text-gray-900">Session token</h1>
+        <p class="mt-1 text-gray-500">
+          Fetch the current session JWT with <code>ClerkService.getToken()</code> and use it to authenticate your backend.
+        </p>
+      </div>
+
+      <div class="rounded-xl border border-gray-200 bg-white p-6 space-y-5">
+        <dl class="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <dt class="text-gray-500">User ID</dt>
+            <dd class="font-mono text-gray-900 truncate">{{ clerk.userId() ?? '—' }}</dd>
+          </div>
+          <div>
+            <dt class="text-gray-500">Session ID</dt>
+            <dd class="font-mono text-gray-900 truncate">{{ clerk.sessionId() ?? '—' }}</dd>
+          </div>
+          <div>
+            <dt class="text-gray-500">Org role</dt>
+            <dd class="font-mono text-gray-900">{{ clerk.orgRole() ?? '—' }}</dd>
+          </div>
+          <div>
+            <dt class="text-gray-500">Org slug</dt>
+            <dd class="font-mono text-gray-900">{{ clerk.orgSlug() ?? '—' }}</dd>
+          </div>
+        </dl>
+
+        <button
+          (click)="fetchToken()"
+          class="inline-flex items-center px-4 py-2 rounded-lg bg-primary text-white text-sm font-medium hover:bg-primary-hover transition-colors"
+        >
+          Get token
+        </button>
+
+        @if (token(); as value) {
+          <pre class="p-3 rounded-lg bg-gray-900 text-green-300 text-xs overflow-x-auto whitespace-pre-wrap break-all">{{ value }}</pre>
+        }
+      </div>
+    </div>
+  `,
+})
+export class SessionTokenPageComponent {
+  readonly clerk = inject(ClerkService);
+  readonly token = signal<string | null>(null);
+
+  async fetchToken(): Promise<void> {
+    this.token.set(await this.clerk.getToken());
+  }
+}

--- a/projects/demo/src/app/pages/dashboard/sessions.component.ts
+++ b/projects/demo/src/app/pages/dashboard/sessions.component.ts
@@ -1,0 +1,52 @@
+import { Component, inject } from '@angular/core';
+import { ClerkService, ClerkUserAvatarComponent } from 'ngx-clerk';
+
+@Component({
+  selector: 'app-sessions-page',
+  imports: [ClerkUserAvatarComponent],
+  template: `
+    <div class="p-8 max-w-3xl">
+      <div class="mb-6">
+        <h1 class="text-2xl font-bold text-gray-900">Active sessions</h1>
+        <p class="mt-1 text-gray-500">
+          Every session on this device from <code>ClerkService.sessions()</code>. Switch with <code>setActive()</code>.
+        </p>
+      </div>
+
+      <div class="rounded-xl border border-gray-200 bg-white divide-y divide-gray-100">
+        @for (session of clerk.sessions(); track session.id) {
+          <div class="flex items-center justify-between gap-4 p-4">
+            <div class="flex items-center gap-3 min-w-0">
+              <clerk-user-avatar />
+              <div class="min-w-0">
+                <p class="text-sm font-medium text-gray-900 truncate">
+                  {{ session.publicUserData.identifier || session.id }}
+                </p>
+                <p class="text-xs text-gray-500">{{ session.status }}</p>
+              </div>
+            </div>
+            @if (session.id === clerk.sessionId()) {
+              <span class="text-xs font-medium text-green-700 bg-green-50 rounded-full px-2.5 py-1">Active</span>
+            } @else {
+              <button
+                (click)="setActive(session.id)"
+                class="text-sm px-3 py-1.5 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors"
+              >
+                Set active
+              </button>
+            }
+          </div>
+        } @empty {
+          <p class="p-4 text-sm text-gray-500">No sessions found.</p>
+        }
+      </div>
+    </div>
+  `,
+})
+export class SessionsPageComponent {
+  readonly clerk = inject(ClerkService);
+
+  setActive(sessionId: string): void {
+    void this.clerk.setActive({ session: sessionId });
+  }
+}

--- a/projects/demo/src/app/pages/home.component.ts
+++ b/projects/demo/src/app/pages/home.component.ts
@@ -1,10 +1,14 @@
-import { Component, inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { ClerkService } from 'ngx-clerk';
+import {
+  ClerkSignedInDirective,
+  ClerkSignedOutDirective,
+  ClerkSignInButtonDirective,
+} from 'ngx-clerk';
 
 @Component({
   selector: 'app-home',
-  imports: [RouterLink],
+  imports: [RouterLink, ClerkSignedInDirective, ClerkSignedOutDirective, ClerkSignInButtonDirective],
   template: `
     <div class="min-h-screen bg-gradient-to-br from-dark to-dark-end text-white">
       <!-- Navigation -->
@@ -19,23 +23,20 @@ import { ClerkService } from 'ngx-clerk';
           >
             GitHub
           </a>
-          @if (clerk.isLoaded()) {
-            @if (clerk.isSignedIn()) {
-              <a
-                routerLink="/dashboard"
-                class="inline-flex items-center px-4 py-2 rounded-lg bg-primary text-white text-sm font-medium hover:bg-primary-hover transition-colors"
-              >
-                Dashboard
-              </a>
-            } @else {
-              <a
-                routerLink="/sign-in"
-                class="inline-flex items-center px-4 py-2 rounded-lg bg-primary text-white text-sm font-medium hover:bg-primary-hover transition-colors"
-              >
-                Sign in
-              </a>
-            }
-          }
+          <a
+            *clerkSignedIn
+            routerLink="/dashboard"
+            class="inline-flex items-center px-4 py-2 rounded-lg bg-primary text-white text-sm font-medium hover:bg-primary-hover transition-colors"
+          >
+            Dashboard
+          </a>
+          <a
+            *clerkSignedOut
+            routerLink="/sign-in"
+            class="inline-flex items-center px-4 py-2 rounded-lg bg-primary text-white text-sm font-medium hover:bg-primary-hover transition-colors"
+          >
+            Sign in
+          </a>
         </div>
       </nav>
 
@@ -51,29 +52,28 @@ import { ClerkService } from 'ngx-clerk';
           Drop-in Clerk components for sign-in, user management, and organizations
         </p>
         <div class="flex items-center justify-center gap-3">
-          @if (clerk.isLoaded() && clerk.isSignedIn()) {
-            <a
-              routerLink="/dashboard"
-              class="inline-flex items-center px-6 py-3 rounded-lg bg-primary text-white font-medium hover:bg-primary-hover transition-colors"
-            >
-              Go to Dashboard
-            </a>
-          } @else {
+          <a
+            *clerkSignedIn
+            routerLink="/dashboard"
+            class="inline-flex items-center px-6 py-3 rounded-lg bg-primary text-white font-medium hover:bg-primary-hover transition-colors"
+          >
+            Go to Dashboard
+          </a>
+          <ng-container *clerkSignedOut>
             <a
               routerLink="/sign-in"
               class="inline-flex items-center px-6 py-3 rounded-lg bg-primary text-white font-medium hover:bg-primary-hover transition-colors"
             >
               Get Started
             </a>
-          }
-          <a
-            href="https://github.com/anagstef/ngx-clerk#readme"
-            target="_blank"
-            rel="noopener"
-            class="inline-flex items-center px-6 py-3 rounded-lg border border-white/20 text-white font-medium hover:bg-white/5 transition-colors"
-          >
-            Documentation
-          </a>
+            <button
+              clerkSignInButton
+              mode="modal"
+              class="inline-flex items-center px-6 py-3 rounded-lg border border-white/20 text-white font-medium hover:bg-white/5 transition-colors"
+            >
+              Sign in (modal)
+            </button>
+          </ng-container>
         </div>
       </section>
 
@@ -118,7 +118,7 @@ import { ClerkService } from 'ngx-clerk';
           <span>Built with ngx-clerk</span>
           <div class="flex items-center gap-6">
             <a href="https://clerk.com/docs" target="_blank" rel="noopener" class="hover:text-white transition-colors">Clerk Docs</a>
-            <a href="https://github.com/anagstef/ngx-clerk" target="_blank" rel="noopener" class="hover:text-white transition-colors">GitHub</a>
+            <a routerLink="/waitlist" class="hover:text-white transition-colors">Waitlist</a>
             <a href="https://www.npmjs.com/package/ngx-clerk" target="_blank" rel="noopener" class="hover:text-white transition-colors">npm</a>
           </div>
         </div>
@@ -126,6 +126,4 @@ import { ClerkService } from 'ngx-clerk';
     </div>
   `,
 })
-export class HomeComponent {
-  clerk = inject(ClerkService);
-}
+export class HomeComponent {}

--- a/projects/demo/src/app/pages/sso-callback.component.ts
+++ b/projects/demo/src/app/pages/sso-callback.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { ClerkAuthenticateWithRedirectCallbackComponent } from 'ngx-clerk';
+
+@Component({
+  selector: 'app-sso-callback',
+  imports: [ClerkAuthenticateWithRedirectCallbackComponent],
+  template: `
+    <div class="min-h-screen bg-gradient-to-br from-dark to-dark-end flex flex-col items-center justify-center px-4 text-white">
+      <div class="animate-pulse text-sm text-gray-300">Completing sign in…</div>
+      <clerk-authenticate-with-redirect-callback
+        [props]="{ signInFallbackRedirectUrl: '/dashboard', signUpFallbackRedirectUrl: '/dashboard' }"
+      />
+    </div>
+  `,
+})
+export class SsoCallbackComponent {}

--- a/projects/demo/src/app/pages/waitlist.component.ts
+++ b/projects/demo/src/app/pages/waitlist.component.ts
@@ -1,18 +1,17 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { ClerkGoogleOneTapComponent, ClerkSignInComponent } from 'ngx-clerk';
+import { ClerkWaitlistComponent } from 'ngx-clerk';
 
 @Component({
-  selector: 'app-sign-in',
-  imports: [RouterLink, ClerkSignInComponent, ClerkGoogleOneTapComponent],
+  selector: 'app-waitlist',
+  imports: [RouterLink, ClerkWaitlistComponent],
   template: `
     <div class="min-h-screen bg-gradient-to-br from-dark to-dark-end flex flex-col items-center justify-center px-4">
       <a routerLink="/" class="text-sm text-gray-400 hover:text-white transition-colors mb-8">
         &larr; Back to home
       </a>
-      <clerk-sign-in [props]="{ routing: 'path', path: '/sign-in', signUpUrl: '/sign-up' }" />
-      <clerk-google-one-tap />
+      <clerk-waitlist />
     </div>
   `,
 })
-export class SignInComponent {}
+export class WaitlistComponent {}

--- a/projects/ngx-clerk/package.json
+++ b/projects/ngx-clerk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngx-clerk",
   "version": "1.0.0",
-  "description": "Unofficial Clerk.com SDK for Angular",
+  "description": "Unofficial Clerk SDK for Angular (Core 3) — components, services, directives, and route guards",
   "keywords": [
     "clerk",
     "typescript",
@@ -23,7 +23,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=18.19.0"
   },
   "author": "https://github.com/anagstef",
   "dependencies": {

--- a/projects/ngx-clerk/src/lib/components/authenticate-with-redirect-callback.component.spec.ts
+++ b/projects/ngx-clerk/src/lib/components/authenticate-with-redirect-callback.component.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ClerkAuthenticateWithRedirectCallbackComponent } from './authenticate-with-redirect-callback.component';
+import { MockClerkService, provideMockClerk } from '../testing/mock-clerk';
+
+@Component({
+  standalone: true,
+  imports: [ClerkAuthenticateWithRedirectCallbackComponent],
+  template: `<clerk-authenticate-with-redirect-callback [props]="props" />`,
+})
+class HostComponent {
+  props = { signInForceRedirectUrl: '/dashboard' };
+}
+
+describe('ClerkAuthenticateWithRedirectCallbackComponent', () => {
+  let mock: MockClerkService;
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(() => {
+    const { mock: m, providers } = provideMockClerk();
+    mock = m;
+    TestBed.configureTestingModule({ imports: [HostComponent], providers });
+    fixture = TestBed.createComponent(HostComponent);
+  });
+
+  it('does nothing before Clerk loads', () => {
+    fixture.detectChanges();
+    expect(mock.handleRedirectCallback).not.toHaveBeenCalled();
+  });
+
+  it('handles the redirect callback once Clerk is available', () => {
+    mock.clerk.set(mock.instance);
+    fixture.detectChanges();
+
+    expect(mock.handleRedirectCallback).toHaveBeenCalledWith({ signInForceRedirectUrl: '/dashboard' });
+  });
+});

--- a/projects/ngx-clerk/src/lib/components/authenticate-with-redirect-callback.component.ts
+++ b/projects/ngx-clerk/src/lib/components/authenticate-with-redirect-callback.component.ts
@@ -1,0 +1,38 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation, effect, inject, input } from '@angular/core';
+import type { HandleOAuthCallbackParams } from '@clerk/shared/types';
+import { ClerkService } from '../services/clerk.service';
+
+/**
+ * Completes an OAuth/SSO redirect flow. Place it on your callback route (e.g.
+ * `/sso-callback`); it calls `handleRedirectCallback()` once Clerk has loaded.
+ *
+ * @example
+ * ```html
+ * <clerk-authenticate-with-redirect-callback
+ *   [props]="{ signInForceRedirectUrl: '/dashboard' }" />
+ * ```
+ */
+@Component({
+  selector: 'clerk-authenticate-with-redirect-callback',
+  standalone: true,
+  template: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class ClerkAuthenticateWithRedirectCallbackComponent {
+  /** Parameters forwarded to `handleRedirectCallback`. */
+  readonly props = input<HandleOAuthCallbackParams | undefined>(undefined);
+
+  private readonly _clerk = inject(ClerkService);
+  private _handled = false;
+
+  constructor() {
+    effect(() => {
+      const clerk = this._clerk.clerk();
+      if (clerk && !this._handled) {
+        this._handled = true;
+        void this._clerk.handleRedirectCallback(this.props());
+      }
+    });
+  }
+}

--- a/projects/ngx-clerk/src/lib/components/create-organization.component.ts
+++ b/projects/ngx-clerk/src/lib/components/create-organization.component.ts
@@ -1,57 +1,26 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  effect,
-  ElementRef,
-  inject,
-  Injector,
-  Input,
-  OnDestroy,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, ViewEncapsulation, input, viewChild } from '@angular/core';
 import type { CreateOrganizationProps } from '@clerk/shared/types';
-import { ClerkService } from '../services/clerk.service';
+import { mountClerkComponent } from '../utils/mount';
 
 @Component({
   selector: 'clerk-create-organization',
   standalone: true,
-  imports: [],
   template: `<div #ref></div>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
 /** Renders the Clerk Create Organization UI component. */
-export class ClerkCreateOrganizationComponent implements AfterViewInit, OnDestroy {
-  @ViewChild('ref') ref: ElementRef | null = null;
-  @Input() props: CreateOrganizationProps | undefined;
+export class ClerkCreateOrganizationComponent {
+  /** Props forwarded to the Clerk Create Organization component. Updates re-mount the component. */
+  readonly props = input<CreateOrganizationProps | undefined>(undefined);
+  private readonly _ref = viewChild<ElementRef<HTMLElement>>('ref');
 
-  private _clerk = inject(ClerkService);
-  private _injector = inject(Injector);
-  private _mounted = false;
-
-  ngAfterViewInit() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref) {
-      clerkInstance.mountCreateOrganization(this.ref.nativeElement, this.props);
-      this._mounted = true;
-    } else {
-      const mountEffect = effect(() => {
-        const c = this._clerk.clerk();
-        if (c && this.ref && !this._mounted) {
-          c.mountCreateOrganization(this.ref.nativeElement, this.props);
-          this._mounted = true;
-          mountEffect.destroy();
-        }
-      }, { injector: this._injector });
-    }
-  }
-
-  ngOnDestroy() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref && this._mounted) {
-      clerkInstance.unmountCreateOrganization(this.ref.nativeElement);
-    }
+  constructor() {
+    mountClerkComponent<CreateOrganizationProps>({
+      node: () => this._ref()?.nativeElement,
+      props: () => this.props(),
+      mount: (clerk, node, props) => clerk.mountCreateOrganization(node, props),
+      unmount: (clerk, node) => clerk.unmountCreateOrganization(node),
+    });
   }
 }

--- a/projects/ngx-clerk/src/lib/components/google-one-tap.component.spec.ts
+++ b/projects/ngx-clerk/src/lib/components/google-one-tap.component.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ClerkGoogleOneTapComponent } from './google-one-tap.component';
+import { MockClerkService, provideMockClerk } from '../testing/mock-clerk';
+
+@Component({
+  standalone: true,
+  imports: [ClerkGoogleOneTapComponent],
+  template: `<clerk-google-one-tap />`,
+})
+class HostComponent {}
+
+describe('ClerkGoogleOneTapComponent', () => {
+  let mock: MockClerkService;
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(() => {
+    const { mock: m, providers } = provideMockClerk();
+    mock = m;
+    TestBed.configureTestingModule({ imports: [HostComponent], providers });
+    fixture = TestBed.createComponent(HostComponent);
+  });
+
+  it('does not open before Clerk loads', () => {
+    fixture.detectChanges();
+    expect(mock.instance['openGoogleOneTap']).not.toHaveBeenCalled();
+  });
+
+  it('opens with default options once Clerk is available', () => {
+    mock.clerk.set(mock.instance);
+    fixture.detectChanges();
+
+    expect(mock.instance['openGoogleOneTap']).toHaveBeenCalledWith(
+      expect.objectContaining({ cancelOnTapOutside: true, itpSupport: true, fedCmSupport: true }),
+    );
+  });
+
+  it('closes on destroy', () => {
+    mock.clerk.set(mock.instance);
+    fixture.detectChanges();
+    fixture.destroy();
+
+    expect(mock.instance['closeGoogleOneTap']).toHaveBeenCalled();
+  });
+});

--- a/projects/ngx-clerk/src/lib/components/google-one-tap.component.ts
+++ b/projects/ngx-clerk/src/lib/components/google-one-tap.component.ts
@@ -1,0 +1,50 @@
+import { ChangeDetectionStrategy, Component, DestroyRef, ViewEncapsulation, effect, inject, input } from '@angular/core';
+import type { GoogleOneTapProps } from '@clerk/shared/types';
+import { ClerkService } from '../services/clerk.service';
+
+/**
+ * Renders Google One Tap sign-in. Opens once Clerk has loaded and closes on
+ * destroy. Prop changes after the initial open are not re-applied.
+ *
+ * @example
+ * ```html
+ * <clerk-google-one-tap />
+ * ```
+ */
+@Component({
+  selector: 'clerk-google-one-tap',
+  standalone: true,
+  template: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class ClerkGoogleOneTapComponent {
+  /** Props forwarded to Google One Tap. */
+  readonly props = input<GoogleOneTapProps | undefined>(undefined);
+
+  private readonly _clerk = inject(ClerkService);
+  private _opened = false;
+
+  constructor() {
+    const destroyRef = inject(DestroyRef);
+
+    effect(() => {
+      const clerk = this._clerk.clerk();
+      if (clerk && !this._opened) {
+        this._opened = true;
+        clerk.openGoogleOneTap({
+          cancelOnTapOutside: true,
+          itpSupport: true,
+          fedCmSupport: true,
+          ...this.props(),
+        });
+      }
+    });
+
+    destroyRef.onDestroy(() => {
+      if (this._opened) {
+        this._clerk.clerk()?.closeGoogleOneTap();
+      }
+    });
+  }
+}

--- a/projects/ngx-clerk/src/lib/components/organization-list.component.ts
+++ b/projects/ngx-clerk/src/lib/components/organization-list.component.ts
@@ -1,57 +1,26 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  effect,
-  ElementRef,
-  inject,
-  Injector,
-  Input,
-  OnDestroy,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, ViewEncapsulation, input, viewChild } from '@angular/core';
 import type { OrganizationListProps } from '@clerk/shared/types';
-import { ClerkService } from '../services/clerk.service';
+import { mountClerkComponent } from '../utils/mount';
 
 @Component({
   selector: 'clerk-organization-list',
   standalone: true,
-  imports: [],
   template: `<div #ref></div>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
 /** Renders the Clerk Organization List UI component. */
-export class ClerkOrganizationListComponent implements AfterViewInit, OnDestroy {
-  @ViewChild('ref') ref: ElementRef | null = null;
-  @Input() props: OrganizationListProps | undefined;
+export class ClerkOrganizationListComponent {
+  /** Props forwarded to the Clerk Organization List component. Updates re-mount the component. */
+  readonly props = input<OrganizationListProps | undefined>(undefined);
+  private readonly _ref = viewChild<ElementRef<HTMLElement>>('ref');
 
-  private _clerk = inject(ClerkService);
-  private _injector = inject(Injector);
-  private _mounted = false;
-
-  ngAfterViewInit() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref) {
-      clerkInstance.mountOrganizationList(this.ref.nativeElement, this.props);
-      this._mounted = true;
-    } else {
-      const mountEffect = effect(() => {
-        const c = this._clerk.clerk();
-        if (c && this.ref && !this._mounted) {
-          c.mountOrganizationList(this.ref.nativeElement, this.props);
-          this._mounted = true;
-          mountEffect.destroy();
-        }
-      }, { injector: this._injector });
-    }
-  }
-
-  ngOnDestroy() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref && this._mounted) {
-      clerkInstance.unmountOrganizationList(this.ref.nativeElement);
-    }
+  constructor() {
+    mountClerkComponent<OrganizationListProps>({
+      node: () => this._ref()?.nativeElement,
+      props: () => this.props(),
+      mount: (clerk, node, props) => clerk.mountOrganizationList(node, props),
+      unmount: (clerk, node) => clerk.unmountOrganizationList(node),
+    });
   }
 }

--- a/projects/ngx-clerk/src/lib/components/organization-profile.component.ts
+++ b/projects/ngx-clerk/src/lib/components/organization-profile.component.ts
@@ -1,57 +1,26 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  effect,
-  ElementRef,
-  inject,
-  Injector,
-  Input,
-  OnDestroy,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, ViewEncapsulation, input, viewChild } from '@angular/core';
 import type { OrganizationProfileProps } from '@clerk/shared/types';
-import { ClerkService } from '../services/clerk.service';
+import { mountClerkComponent } from '../utils/mount';
 
 @Component({
   selector: 'clerk-organization-profile',
   standalone: true,
-  imports: [],
   template: `<div #ref></div>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
 /** Renders the Clerk Organization Profile UI component. */
-export class ClerkOrganizationProfileComponent implements AfterViewInit, OnDestroy {
-  @ViewChild('ref') ref: ElementRef | null = null;
-  @Input() props: OrganizationProfileProps | undefined;
+export class ClerkOrganizationProfileComponent {
+  /** Props forwarded to the Clerk Organization Profile component. Updates re-mount the component. */
+  readonly props = input<OrganizationProfileProps | undefined>(undefined);
+  private readonly _ref = viewChild<ElementRef<HTMLElement>>('ref');
 
-  private _clerk = inject(ClerkService);
-  private _injector = inject(Injector);
-  private _mounted = false;
-
-  ngAfterViewInit() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref) {
-      clerkInstance.mountOrganizationProfile(this.ref.nativeElement, this.props);
-      this._mounted = true;
-    } else {
-      const mountEffect = effect(() => {
-        const c = this._clerk.clerk();
-        if (c && this.ref && !this._mounted) {
-          c.mountOrganizationProfile(this.ref.nativeElement, this.props);
-          this._mounted = true;
-          mountEffect.destroy();
-        }
-      }, { injector: this._injector });
-    }
-  }
-
-  ngOnDestroy() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref && this._mounted) {
-      clerkInstance.unmountOrganizationProfile(this.ref.nativeElement);
-    }
+  constructor() {
+    mountClerkComponent<OrganizationProfileProps>({
+      node: () => this._ref()?.nativeElement,
+      props: () => this.props(),
+      mount: (clerk, node, props) => clerk.mountOrganizationProfile(node, props),
+      unmount: (clerk, node) => clerk.unmountOrganizationProfile(node),
+    });
   }
 }

--- a/projects/ngx-clerk/src/lib/components/organization-switcher.component.ts
+++ b/projects/ngx-clerk/src/lib/components/organization-switcher.component.ts
@@ -1,57 +1,26 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  effect,
-  ElementRef,
-  inject,
-  Injector,
-  Input,
-  OnDestroy,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, ViewEncapsulation, input, viewChild } from '@angular/core';
 import type { OrganizationSwitcherProps } from '@clerk/shared/types';
-import { ClerkService } from '../services/clerk.service';
+import { mountClerkComponent } from '../utils/mount';
 
 @Component({
   selector: 'clerk-organization-switcher',
   standalone: true,
-  imports: [],
   template: `<div #ref></div>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
 /** Renders the Clerk Organization Switcher UI component. */
-export class ClerkOrganizationSwitcherComponent implements AfterViewInit, OnDestroy {
-  @ViewChild('ref') ref: ElementRef | null = null;
-  @Input() props: OrganizationSwitcherProps | undefined;
+export class ClerkOrganizationSwitcherComponent {
+  /** Props forwarded to the Clerk Organization Switcher component. Updates re-mount the component. */
+  readonly props = input<OrganizationSwitcherProps | undefined>(undefined);
+  private readonly _ref = viewChild<ElementRef<HTMLElement>>('ref');
 
-  private _clerk = inject(ClerkService);
-  private _injector = inject(Injector);
-  private _mounted = false;
-
-  ngAfterViewInit() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref) {
-      clerkInstance.mountOrganizationSwitcher(this.ref.nativeElement, this.props);
-      this._mounted = true;
-    } else {
-      const mountEffect = effect(() => {
-        const c = this._clerk.clerk();
-        if (c && this.ref && !this._mounted) {
-          c.mountOrganizationSwitcher(this.ref.nativeElement, this.props);
-          this._mounted = true;
-          mountEffect.destroy();
-        }
-      }, { injector: this._injector });
-    }
-  }
-
-  ngOnDestroy() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref && this._mounted) {
-      clerkInstance.unmountOrganizationSwitcher(this.ref.nativeElement);
-    }
+  constructor() {
+    mountClerkComponent<OrganizationSwitcherProps>({
+      node: () => this._ref()?.nativeElement,
+      props: () => this.props(),
+      mount: (clerk, node, props) => clerk.mountOrganizationSwitcher(node, props),
+      unmount: (clerk, node) => clerk.unmountOrganizationSwitcher(node),
+    });
   }
 }

--- a/projects/ngx-clerk/src/lib/components/pricing-table.component.ts
+++ b/projects/ngx-clerk/src/lib/components/pricing-table.component.ts
@@ -1,57 +1,26 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  effect,
-  ElementRef,
-  inject,
-  Injector,
-  Input,
-  OnDestroy,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, ViewEncapsulation, input, viewChild } from '@angular/core';
 import type { PricingTableProps } from '@clerk/shared/types';
-import { ClerkService } from '../services/clerk.service';
+import { mountClerkComponent } from '../utils/mount';
 
 @Component({
   selector: 'clerk-pricing-table',
   standalone: true,
-  imports: [],
   template: `<div #ref></div>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
 /** Renders the Clerk Pricing Table UI component. */
-export class ClerkPricingTableComponent implements AfterViewInit, OnDestroy {
-  @ViewChild('ref') ref: ElementRef | null = null;
-  @Input() props: PricingTableProps | undefined;
+export class ClerkPricingTableComponent {
+  /** Props forwarded to the Clerk Pricing Table component. Updates re-mount the component. */
+  readonly props = input<PricingTableProps | undefined>(undefined);
+  private readonly _ref = viewChild<ElementRef<HTMLElement>>('ref');
 
-  private _clerk = inject(ClerkService);
-  private _injector = inject(Injector);
-  private _mounted = false;
-
-  ngAfterViewInit() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref) {
-      clerkInstance.mountPricingTable(this.ref.nativeElement, this.props);
-      this._mounted = true;
-    } else {
-      const mountEffect = effect(() => {
-        const c = this._clerk.clerk();
-        if (c && this.ref && !this._mounted) {
-          c.mountPricingTable(this.ref.nativeElement, this.props);
-          this._mounted = true;
-          mountEffect.destroy();
-        }
-      }, { injector: this._injector });
-    }
-  }
-
-  ngOnDestroy() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref && this._mounted) {
-      clerkInstance.unmountPricingTable(this.ref.nativeElement);
-    }
+  constructor() {
+    mountClerkComponent<PricingTableProps>({
+      node: () => this._ref()?.nativeElement,
+      props: () => this.props(),
+      mount: (clerk, node, props) => clerk.mountPricingTable(node, props),
+      unmount: (clerk, node) => clerk.unmountPricingTable(node),
+    });
   }
 }

--- a/projects/ngx-clerk/src/lib/components/sign-in.component.spec.ts
+++ b/projects/ngx-clerk/src/lib/components/sign-in.component.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { SignInProps } from '@clerk/shared/types';
+import { ClerkSignInComponent } from './sign-in.component';
+import { MockClerkService, provideMockClerk } from '../testing/mock-clerk';
+
+@Component({
+  standalone: true,
+  imports: [ClerkSignInComponent],
+  template: `<clerk-sign-in [props]="props()" />`,
+})
+class HostComponent {
+  readonly props = signal<SignInProps | undefined>(undefined);
+}
+
+describe('ClerkSignInComponent', () => {
+  let mock: MockClerkService;
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(() => {
+    const { mock: m, providers } = provideMockClerk();
+    mock = m;
+    TestBed.configureTestingModule({ imports: [HostComponent], providers });
+    fixture = TestBed.createComponent(HostComponent);
+  });
+
+  it('does not mount until Clerk has loaded', () => {
+    fixture.detectChanges();
+    expect(mock.instance['mountSignIn']).not.toHaveBeenCalled();
+  });
+
+  it('mounts into a host element once Clerk is available', () => {
+    mock.clerk.set(mock.instance);
+    fixture.detectChanges();
+
+    expect(mock.instance['mountSignIn']).toHaveBeenCalledTimes(1);
+    const node = mock.instance['mountSignIn'].mock.calls[0][0];
+    expect(node).toBeInstanceOf(HTMLElement);
+  });
+
+  it('unmounts on destroy', () => {
+    mock.clerk.set(mock.instance);
+    fixture.detectChanges();
+    fixture.destroy();
+
+    expect(mock.instance['unmountSignIn']).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-mounts when props change', () => {
+    mock.clerk.set(mock.instance);
+    fixture.detectChanges();
+    expect(mock.instance['mountSignIn']).toHaveBeenCalledTimes(1);
+
+    fixture.componentInstance.props.set({ routing: 'hash' });
+    fixture.detectChanges();
+
+    expect(mock.instance['unmountSignIn']).toHaveBeenCalledTimes(1);
+    expect(mock.instance['mountSignIn']).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not re-mount when an equal props literal is re-assigned', () => {
+    mock.clerk.set(mock.instance);
+    fixture.componentInstance.props.set({ routing: 'hash' });
+    fixture.detectChanges();
+    expect(mock.instance['mountSignIn']).toHaveBeenCalledTimes(1);
+
+    // Same content, new object reference.
+    fixture.componentInstance.props.set({ routing: 'hash' });
+    fixture.detectChanges();
+    expect(mock.instance['mountSignIn']).toHaveBeenCalledTimes(1);
+  });
+});

--- a/projects/ngx-clerk/src/lib/components/sign-in.component.ts
+++ b/projects/ngx-clerk/src/lib/components/sign-in.component.ts
@@ -1,57 +1,26 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  effect,
-  ElementRef,
-  inject,
-  Injector,
-  Input,
-  OnDestroy,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, ViewEncapsulation, input, viewChild } from '@angular/core';
 import type { SignInProps } from '@clerk/shared/types';
-import { ClerkService } from '../services/clerk.service';
+import { mountClerkComponent } from '../utils/mount';
 
 @Component({
   selector: 'clerk-sign-in',
   standalone: true,
-  imports: [],
   template: `<div #ref></div>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
 /** Renders the Clerk Sign In UI component. */
-export class ClerkSignInComponent implements AfterViewInit, OnDestroy {
-  @ViewChild('ref') ref: ElementRef | null = null;
-  @Input() props: SignInProps | undefined;
+export class ClerkSignInComponent {
+  /** Props forwarded to the Clerk Sign In component. Updates re-mount the component. */
+  readonly props = input<SignInProps | undefined>(undefined);
+  private readonly _ref = viewChild<ElementRef<HTMLElement>>('ref');
 
-  private _clerk = inject(ClerkService);
-  private _injector = inject(Injector);
-  private _mounted = false;
-
-  ngAfterViewInit() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref) {
-      clerkInstance.mountSignIn(this.ref.nativeElement, this.props);
-      this._mounted = true;
-    } else {
-      const mountEffect = effect(() => {
-        const c = this._clerk.clerk();
-        if (c && this.ref && !this._mounted) {
-          c.mountSignIn(this.ref.nativeElement, this.props);
-          this._mounted = true;
-          mountEffect.destroy();
-        }
-      }, { injector: this._injector });
-    }
-  }
-
-  ngOnDestroy() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref && this._mounted) {
-      clerkInstance.unmountSignIn(this.ref.nativeElement);
-    }
+  constructor() {
+    mountClerkComponent<SignInProps>({
+      node: () => this._ref()?.nativeElement,
+      props: () => this.props(),
+      mount: (clerk, node, props) => clerk.mountSignIn(node, props),
+      unmount: (clerk, node) => clerk.unmountSignIn(node),
+    });
   }
 }

--- a/projects/ngx-clerk/src/lib/components/sign-up.component.ts
+++ b/projects/ngx-clerk/src/lib/components/sign-up.component.ts
@@ -1,57 +1,26 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  effect,
-  ElementRef,
-  inject,
-  Injector,
-  Input,
-  OnDestroy,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, ViewEncapsulation, input, viewChild } from '@angular/core';
 import type { SignUpProps } from '@clerk/shared/types';
-import { ClerkService } from '../services/clerk.service';
+import { mountClerkComponent } from '../utils/mount';
 
 @Component({
   selector: 'clerk-sign-up',
   standalone: true,
-  imports: [],
   template: `<div #ref></div>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
 /** Renders the Clerk Sign Up UI component. */
-export class ClerkSignUpComponent implements AfterViewInit, OnDestroy {
-  @ViewChild('ref') ref: ElementRef | null = null;
-  @Input() props: SignUpProps | undefined;
+export class ClerkSignUpComponent {
+  /** Props forwarded to the Clerk Sign Up component. Updates re-mount the component. */
+  readonly props = input<SignUpProps | undefined>(undefined);
+  private readonly _ref = viewChild<ElementRef<HTMLElement>>('ref');
 
-  private _clerk = inject(ClerkService);
-  private _injector = inject(Injector);
-  private _mounted = false;
-
-  ngAfterViewInit() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref) {
-      clerkInstance.mountSignUp(this.ref.nativeElement, this.props);
-      this._mounted = true;
-    } else {
-      const mountEffect = effect(() => {
-        const c = this._clerk.clerk();
-        if (c && this.ref && !this._mounted) {
-          c.mountSignUp(this.ref.nativeElement, this.props);
-          this._mounted = true;
-          mountEffect.destroy();
-        }
-      }, { injector: this._injector });
-    }
-  }
-
-  ngOnDestroy() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref && this._mounted) {
-      clerkInstance.unmountSignUp(this.ref.nativeElement);
-    }
+  constructor() {
+    mountClerkComponent<SignUpProps>({
+      node: () => this._ref()?.nativeElement,
+      props: () => this.props(),
+      mount: (clerk, node, props) => clerk.mountSignUp(node, props),
+      unmount: (clerk, node) => clerk.unmountSignUp(node),
+    });
   }
 }

--- a/projects/ngx-clerk/src/lib/components/user-avatar.component.ts
+++ b/projects/ngx-clerk/src/lib/components/user-avatar.component.ts
@@ -1,57 +1,26 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  effect,
-  ElementRef,
-  inject,
-  Injector,
-  Input,
-  OnDestroy,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, ViewEncapsulation, input, viewChild } from '@angular/core';
 import type { UserAvatarProps } from '@clerk/shared/types';
-import { ClerkService } from '../services/clerk.service';
+import { mountClerkComponent } from '../utils/mount';
 
 @Component({
   selector: 'clerk-user-avatar',
   standalone: true,
-  imports: [],
   template: `<div #ref></div>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
 /** Renders the Clerk User Avatar UI component. */
-export class ClerkUserAvatarComponent implements AfterViewInit, OnDestroy {
-  @ViewChild('ref') ref: ElementRef | null = null;
-  @Input() props: UserAvatarProps | undefined;
+export class ClerkUserAvatarComponent {
+  /** Props forwarded to the Clerk User Avatar component. Updates re-mount the component. */
+  readonly props = input<UserAvatarProps | undefined>(undefined);
+  private readonly _ref = viewChild<ElementRef<HTMLElement>>('ref');
 
-  private _clerk = inject(ClerkService);
-  private _injector = inject(Injector);
-  private _mounted = false;
-
-  ngAfterViewInit() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref) {
-      clerkInstance.mountUserAvatar(this.ref.nativeElement, this.props);
-      this._mounted = true;
-    } else {
-      const mountEffect = effect(() => {
-        const c = this._clerk.clerk();
-        if (c && this.ref && !this._mounted) {
-          c.mountUserAvatar(this.ref.nativeElement, this.props);
-          this._mounted = true;
-          mountEffect.destroy();
-        }
-      }, { injector: this._injector });
-    }
-  }
-
-  ngOnDestroy() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref && this._mounted) {
-      clerkInstance.unmountUserAvatar(this.ref.nativeElement);
-    }
+  constructor() {
+    mountClerkComponent<UserAvatarProps>({
+      node: () => this._ref()?.nativeElement,
+      props: () => this.props(),
+      mount: (clerk, node, props) => clerk.mountUserAvatar(node, props),
+      unmount: (clerk, node) => clerk.unmountUserAvatar(node),
+    });
   }
 }

--- a/projects/ngx-clerk/src/lib/components/user-button.component.ts
+++ b/projects/ngx-clerk/src/lib/components/user-button.component.ts
@@ -1,57 +1,26 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  effect,
-  ElementRef,
-  inject,
-  Injector,
-  Input,
-  OnDestroy,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, ViewEncapsulation, input, viewChild } from '@angular/core';
 import type { UserButtonProps } from '@clerk/shared/types';
-import { ClerkService } from '../services/clerk.service';
+import { mountClerkComponent } from '../utils/mount';
 
 @Component({
   selector: 'clerk-user-button',
   standalone: true,
-  imports: [],
   template: `<div #ref></div>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
 /** Renders the Clerk User Button UI component. */
-export class ClerkUserButtonComponent implements AfterViewInit, OnDestroy {
-  @ViewChild('ref') ref: ElementRef | null = null;
-  @Input() props: UserButtonProps | undefined;
+export class ClerkUserButtonComponent {
+  /** Props forwarded to the Clerk User Button component. Updates re-mount the component. */
+  readonly props = input<UserButtonProps | undefined>(undefined);
+  private readonly _ref = viewChild<ElementRef<HTMLElement>>('ref');
 
-  private _clerk = inject(ClerkService);
-  private _injector = inject(Injector);
-  private _mounted = false;
-
-  ngAfterViewInit() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref) {
-      clerkInstance.mountUserButton(this.ref.nativeElement, this.props);
-      this._mounted = true;
-    } else {
-      const mountEffect = effect(() => {
-        const c = this._clerk.clerk();
-        if (c && this.ref && !this._mounted) {
-          c.mountUserButton(this.ref.nativeElement, this.props);
-          this._mounted = true;
-          mountEffect.destroy();
-        }
-      }, { injector: this._injector });
-    }
-  }
-
-  ngOnDestroy() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref && this._mounted) {
-      clerkInstance.unmountUserButton(this.ref.nativeElement);
-    }
+  constructor() {
+    mountClerkComponent<UserButtonProps>({
+      node: () => this._ref()?.nativeElement,
+      props: () => this.props(),
+      mount: (clerk, node, props) => clerk.mountUserButton(node, props),
+      unmount: (clerk, node) => clerk.unmountUserButton(node),
+    });
   }
 }

--- a/projects/ngx-clerk/src/lib/components/user-profile.component.ts
+++ b/projects/ngx-clerk/src/lib/components/user-profile.component.ts
@@ -1,57 +1,26 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  effect,
-  ElementRef,
-  inject,
-  Injector,
-  Input,
-  OnDestroy,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, ViewEncapsulation, input, viewChild } from '@angular/core';
 import type { UserProfileProps } from '@clerk/shared/types';
-import { ClerkService } from '../services/clerk.service';
+import { mountClerkComponent } from '../utils/mount';
 
 @Component({
   selector: 'clerk-user-profile',
   standalone: true,
-  imports: [],
   template: `<div #ref></div>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
 /** Renders the Clerk User Profile UI component. */
-export class ClerkUserProfileComponent implements AfterViewInit, OnDestroy {
-  @ViewChild('ref') ref: ElementRef | null = null;
-  @Input() props: UserProfileProps | undefined;
+export class ClerkUserProfileComponent {
+  /** Props forwarded to the Clerk User Profile component. Updates re-mount the component. */
+  readonly props = input<UserProfileProps | undefined>(undefined);
+  private readonly _ref = viewChild<ElementRef<HTMLElement>>('ref');
 
-  private _clerk = inject(ClerkService);
-  private _injector = inject(Injector);
-  private _mounted = false;
-
-  ngAfterViewInit() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref) {
-      clerkInstance.mountUserProfile(this.ref.nativeElement, this.props);
-      this._mounted = true;
-    } else {
-      const mountEffect = effect(() => {
-        const c = this._clerk.clerk();
-        if (c && this.ref && !this._mounted) {
-          c.mountUserProfile(this.ref.nativeElement, this.props);
-          this._mounted = true;
-          mountEffect.destroy();
-        }
-      }, { injector: this._injector });
-    }
-  }
-
-  ngOnDestroy() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref && this._mounted) {
-      clerkInstance.unmountUserProfile(this.ref.nativeElement);
-    }
+  constructor() {
+    mountClerkComponent<UserProfileProps>({
+      node: () => this._ref()?.nativeElement,
+      props: () => this.props(),
+      mount: (clerk, node, props) => clerk.mountUserProfile(node, props),
+      unmount: (clerk, node) => clerk.unmountUserProfile(node),
+    });
   }
 }

--- a/projects/ngx-clerk/src/lib/components/waitlist.component.ts
+++ b/projects/ngx-clerk/src/lib/components/waitlist.component.ts
@@ -1,57 +1,26 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  effect,
-  ElementRef,
-  inject,
-  Injector,
-  Input,
-  OnDestroy,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, ViewEncapsulation, input, viewChild } from '@angular/core';
 import type { WaitlistProps } from '@clerk/shared/types';
-import { ClerkService } from '../services/clerk.service';
+import { mountClerkComponent } from '../utils/mount';
 
 @Component({
   selector: 'clerk-waitlist',
   standalone: true,
-  imports: [],
   template: `<div #ref></div>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
 /** Renders the Clerk Waitlist UI component. */
-export class ClerkWaitlistComponent implements AfterViewInit, OnDestroy {
-  @ViewChild('ref') ref: ElementRef | null = null;
-  @Input() props: WaitlistProps | undefined;
+export class ClerkWaitlistComponent {
+  /** Props forwarded to the Clerk Waitlist component. Updates re-mount the component. */
+  readonly props = input<WaitlistProps | undefined>(undefined);
+  private readonly _ref = viewChild<ElementRef<HTMLElement>>('ref');
 
-  private _clerk = inject(ClerkService);
-  private _injector = inject(Injector);
-  private _mounted = false;
-
-  ngAfterViewInit() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref) {
-      clerkInstance.mountWaitlist(this.ref.nativeElement, this.props);
-      this._mounted = true;
-    } else {
-      const mountEffect = effect(() => {
-        const c = this._clerk.clerk();
-        if (c && this.ref && !this._mounted) {
-          c.mountWaitlist(this.ref.nativeElement, this.props);
-          this._mounted = true;
-          mountEffect.destroy();
-        }
-      }, { injector: this._injector });
-    }
-  }
-
-  ngOnDestroy() {
-    const clerkInstance = this._clerk.clerk();
-    if (clerkInstance && this.ref && this._mounted) {
-      clerkInstance.unmountWaitlist(this.ref.nativeElement);
-    }
+  constructor() {
+    mountClerkComponent<WaitlistProps>({
+      node: () => this._ref()?.nativeElement,
+      props: () => this.props(),
+      mount: (clerk, node, props) => clerk.mountWaitlist(node, props),
+      unmount: (clerk, node) => clerk.unmountWaitlist(node),
+    });
   }
 }

--- a/projects/ngx-clerk/src/lib/directives/button.directives.spec.ts
+++ b/projects/ngx-clerk/src/lib/directives/button.directives.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ClerkSignInButtonDirective,
+  ClerkSignOutButtonDirective,
+  ClerkSignUpButtonDirective,
+} from './button.directives';
+import { MockClerkService, provideMockClerk } from '../testing/mock-clerk';
+
+@Component({
+  standalone: true,
+  imports: [ClerkSignInButtonDirective, ClerkSignUpButtonDirective, ClerkSignOutButtonDirective],
+  template: `
+    <button class="si-redirect" clerkSignInButton fallbackRedirectUrl="/dash">in</button>
+    <button class="si-modal" clerkSignInButton mode="modal">in</button>
+    <button class="su" clerkSignUpButton>up</button>
+    <button class="so" clerkSignOutButton redirectUrl="/bye">out</button>
+  `,
+})
+class HostComponent {}
+
+describe('button directives', () => {
+  let mock: MockClerkService;
+  let fixture: ComponentFixture<HostComponent>;
+  const click = (cls: string) => fixture.nativeElement.querySelector(`.${cls}`).click();
+
+  beforeEach(() => {
+    const { mock: m, providers } = provideMockClerk();
+    mock = m;
+    TestBed.configureTestingModule({ imports: [HostComponent], providers });
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+  });
+
+  it('redirects to sign-in by default, remapping the fallback url', () => {
+    click('si-redirect');
+    expect(mock.redirectToSignIn).toHaveBeenCalledWith(
+      expect.objectContaining({ signInFallbackRedirectUrl: '/dash' }),
+    );
+    expect(mock.openSignIn).not.toHaveBeenCalled();
+  });
+
+  it('opens the sign-in modal in modal mode', () => {
+    click('si-modal');
+    expect(mock.openSignIn).toHaveBeenCalled();
+    expect(mock.redirectToSignIn).not.toHaveBeenCalled();
+  });
+
+  it('redirects to sign-up on the sign-up button', () => {
+    click('su');
+    expect(mock.redirectToSignUp).toHaveBeenCalled();
+  });
+
+  it('signs out with the provided redirect url', () => {
+    click('so');
+    expect(mock.signOut).toHaveBeenCalledWith(expect.objectContaining({ redirectUrl: '/bye' }));
+  });
+});

--- a/projects/ngx-clerk/src/lib/directives/button.directives.ts
+++ b/projects/ngx-clerk/src/lib/directives/button.directives.ts
@@ -1,0 +1,120 @@
+import { Directive, inject, input } from '@angular/core';
+import { ClerkService } from '../services/clerk.service';
+
+/** Sign-in/up button trigger mode. */
+export type ClerkButtonMode = 'redirect' | 'modal';
+
+/**
+ * Attribute directive that triggers Clerk sign-in on click. In `redirect` mode
+ * (default) it navigates to the sign-in page; in `modal` mode it opens the
+ * sign-in modal. Apply it to your own button so you keep full control of styling.
+ *
+ * @example
+ * ```html
+ * <button clerkSignInButton>Sign in</button>
+ * <button clerkSignInButton mode="modal">Sign in</button>
+ * ```
+ */
+@Directive({
+  selector: '[clerkSignInButton]',
+  standalone: true,
+  host: { '(click)': 'onClick()' },
+})
+export class ClerkSignInButtonDirective {
+  private readonly _clerk = inject(ClerkService);
+
+  /** `'redirect'` (default) navigates to the sign-in page; `'modal'` opens the modal. */
+  readonly mode = input<ClerkButtonMode>('redirect');
+  readonly forceRedirectUrl = input<string>();
+  readonly fallbackRedirectUrl = input<string>();
+  readonly signUpForceRedirectUrl = input<string>();
+  readonly signUpFallbackRedirectUrl = input<string>();
+
+  onClick(): void {
+    if (this.mode() === 'modal') {
+      this._clerk.openSignIn({
+        forceRedirectUrl: this.forceRedirectUrl(),
+        fallbackRedirectUrl: this.fallbackRedirectUrl(),
+        signUpForceRedirectUrl: this.signUpForceRedirectUrl(),
+        signUpFallbackRedirectUrl: this.signUpFallbackRedirectUrl(),
+      });
+      return;
+    }
+    this._clerk.redirectToSignIn({
+      signInForceRedirectUrl: this.forceRedirectUrl(),
+      signInFallbackRedirectUrl: this.fallbackRedirectUrl(),
+      signUpForceRedirectUrl: this.signUpForceRedirectUrl(),
+      signUpFallbackRedirectUrl: this.signUpFallbackRedirectUrl(),
+    });
+  }
+}
+
+/**
+ * Attribute directive that triggers Clerk sign-up on click. In `redirect` mode
+ * (default) it navigates to the sign-up page; in `modal` mode it opens the
+ * sign-up modal.
+ *
+ * @example
+ * ```html
+ * <button clerkSignUpButton>Create account</button>
+ * ```
+ */
+@Directive({
+  selector: '[clerkSignUpButton]',
+  standalone: true,
+  host: { '(click)': 'onClick()' },
+})
+export class ClerkSignUpButtonDirective {
+  private readonly _clerk = inject(ClerkService);
+
+  /** `'redirect'` (default) navigates to the sign-up page; `'modal'` opens the modal. */
+  readonly mode = input<ClerkButtonMode>('redirect');
+  readonly forceRedirectUrl = input<string>();
+  readonly fallbackRedirectUrl = input<string>();
+  readonly signInForceRedirectUrl = input<string>();
+  readonly signInFallbackRedirectUrl = input<string>();
+
+  onClick(): void {
+    if (this.mode() === 'modal') {
+      this._clerk.openSignUp({
+        forceRedirectUrl: this.forceRedirectUrl(),
+        fallbackRedirectUrl: this.fallbackRedirectUrl(),
+        signInForceRedirectUrl: this.signInForceRedirectUrl(),
+        signInFallbackRedirectUrl: this.signInFallbackRedirectUrl(),
+      });
+      return;
+    }
+    this._clerk.redirectToSignUp({
+      signUpForceRedirectUrl: this.forceRedirectUrl(),
+      signUpFallbackRedirectUrl: this.fallbackRedirectUrl(),
+      signInForceRedirectUrl: this.signInForceRedirectUrl(),
+      signInFallbackRedirectUrl: this.signInFallbackRedirectUrl(),
+    });
+  }
+}
+
+/**
+ * Attribute directive that signs the current user out on click.
+ *
+ * @example
+ * ```html
+ * <button clerkSignOutButton redirectUrl="/">Sign out</button>
+ * ```
+ */
+@Directive({
+  selector: '[clerkSignOutButton]',
+  standalone: true,
+  host: { '(click)': 'onClick()' },
+})
+export class ClerkSignOutButtonDirective {
+  private readonly _clerk = inject(ClerkService);
+
+  /** URL to navigate to after signing out. */
+  readonly redirectUrl = input<string>();
+  /** A specific session to sign out of. Omit to sign out of all sessions. */
+  readonly sessionId = input<string>();
+
+  onClick(): void {
+    void this._clerk.signOut({ redirectUrl: this.redirectUrl(), sessionId: this.sessionId() });
+  }
+}

--- a/projects/ngx-clerk/src/lib/directives/control-flow.directive.spec.ts
+++ b/projects/ngx-clerk/src/lib/directives/control-flow.directive.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ClerkLoadedDirective,
+  ClerkLoadingDirective,
+  ClerkSignedInDirective,
+  ClerkSignedOutDirective,
+} from './control-flow.directive';
+import { MockClerkService, provideMockClerk } from '../testing/mock-clerk';
+
+@Component({
+  standalone: true,
+  imports: [ClerkSignedInDirective, ClerkSignedOutDirective, ClerkLoadedDirective, ClerkLoadingDirective],
+  template: `
+    <span class="in" *clerkSignedIn>in</span>
+    <span class="out" *clerkSignedOut>out</span>
+    <span class="loaded" *clerkLoaded>loaded</span>
+    <span class="loading" *clerkLoading>loading</span>
+  `,
+})
+class HostComponent {}
+
+describe('control-flow directives', () => {
+  let mock: MockClerkService;
+  let fixture: ComponentFixture<HostComponent>;
+
+  const present = (cls: string) => !!fixture.nativeElement.querySelector(`.${cls}`);
+
+  beforeEach(() => {
+    const { mock: m, providers } = provideMockClerk();
+    mock = m;
+    TestBed.configureTestingModule({ imports: [HostComponent], providers });
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+  });
+
+  it('renders only *clerkLoading before Clerk has loaded', () => {
+    expect(present('loading')).toBe(true);
+    expect(present('loaded')).toBe(false);
+    expect(present('in')).toBe(false);
+    expect(present('out')).toBe(false);
+  });
+
+  it('renders *clerkLoaded and *clerkSignedOut once loaded and signed out', () => {
+    mock.isLoaded.set(true);
+    fixture.detectChanges();
+
+    expect(present('loaded')).toBe(true);
+    expect(present('loading')).toBe(false);
+    expect(present('out')).toBe(true);
+    expect(present('in')).toBe(false);
+  });
+
+  it('renders *clerkSignedIn and hides *clerkSignedOut once signed in', () => {
+    mock.isLoaded.set(true);
+    mock.isSignedIn.set(true);
+    fixture.detectChanges();
+
+    expect(present('in')).toBe(true);
+    expect(present('out')).toBe(false);
+    expect(present('loaded')).toBe(true);
+  });
+
+  it('reacts to signing back out', () => {
+    mock.isLoaded.set(true);
+    mock.isSignedIn.set(true);
+    fixture.detectChanges();
+    expect(present('in')).toBe(true);
+
+    mock.isSignedIn.set(false);
+    fixture.detectChanges();
+    expect(present('in')).toBe(false);
+    expect(present('out')).toBe(true);
+  });
+});

--- a/projects/ngx-clerk/src/lib/directives/control-flow.directive.ts
+++ b/projects/ngx-clerk/src/lib/directives/control-flow.directive.ts
@@ -1,0 +1,92 @@
+import { Directive, EmbeddedViewRef, TemplateRef, ViewContainerRef, effect, inject } from '@angular/core';
+import { ClerkService } from '../services/clerk.service';
+
+/**
+ * Base class for Clerk conditional structural directives. Renders the template
+ * when {@link shouldRender} is `true`, clears it otherwise, reactively.
+ */
+@Directive()
+export abstract class ClerkConditionalDirective {
+  protected readonly clerk = inject(ClerkService);
+  private readonly _templateRef = inject<TemplateRef<unknown>>(TemplateRef);
+  private readonly _viewContainer = inject(ViewContainerRef);
+  private _viewRef: EmbeddedViewRef<unknown> | null = null;
+
+  /** Whether the directive's template should currently be rendered. */
+  protected abstract shouldRender(): boolean;
+
+  constructor() {
+    effect(() => {
+      const render = this.shouldRender();
+      if (render && !this._viewRef) {
+        this._viewRef = this._viewContainer.createEmbeddedView(this._templateRef);
+      } else if (!render && this._viewRef) {
+        this._viewContainer.clear();
+        this._viewRef = null;
+      }
+    });
+  }
+}
+
+/**
+ * Structural directive that renders its content only when a user is signed in.
+ *
+ * @example
+ * ```html
+ * <p *clerkSignedIn>Welcome back!</p>
+ * ```
+ */
+@Directive({ selector: '[clerkSignedIn]', standalone: true })
+export class ClerkSignedInDirective extends ClerkConditionalDirective {
+  protected shouldRender(): boolean {
+    return this.clerk.isSignedIn();
+  }
+}
+
+/**
+ * Structural directive that renders its content only when Clerk has loaded and
+ * no user is signed in.
+ *
+ * @example
+ * ```html
+ * <button *clerkSignedOut clerkSignInButton>Sign in</button>
+ * ```
+ */
+@Directive({ selector: '[clerkSignedOut]', standalone: true })
+export class ClerkSignedOutDirective extends ClerkConditionalDirective {
+  protected shouldRender(): boolean {
+    return this.clerk.isLoaded() && !this.clerk.isSignedIn();
+  }
+}
+
+/**
+ * Structural directive that renders its content only after Clerk has finished
+ * loading.
+ *
+ * @example
+ * ```html
+ * <div *clerkLoaded><clerk-user-button /></div>
+ * ```
+ */
+@Directive({ selector: '[clerkLoaded]', standalone: true })
+export class ClerkLoadedDirective extends ClerkConditionalDirective {
+  protected shouldRender(): boolean {
+    return this.clerk.isLoaded();
+  }
+}
+
+/**
+ * Structural directive that renders its content only while Clerk is still
+ * loading.
+ *
+ * @example
+ * ```html
+ * <span *clerkLoading>Loading…</span>
+ * ```
+ */
+@Directive({ selector: '[clerkLoading]', standalone: true })
+export class ClerkLoadingDirective extends ClerkConditionalDirective {
+  protected shouldRender(): boolean {
+    return !this.clerk.isLoaded();
+  }
+}

--- a/projects/ngx-clerk/src/lib/directives/protect.directive.spec.ts
+++ b/projects/ngx-clerk/src/lib/directives/protect.directive.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ClerkProtectDirective } from './protect.directive';
+import { MockClerkService, provideMockClerk } from '../testing/mock-clerk';
+
+@Component({
+  standalone: true,
+  imports: [ClerkProtectDirective],
+  template: `
+    <span class="admin" *clerkProtect="{ role: 'org:admin' }; else denied">admin</span>
+    <ng-template #denied><span class="denied">denied</span></ng-template>
+  `,
+})
+class HostComponent {}
+
+describe('ClerkProtectDirective', () => {
+  let mock: MockClerkService;
+  let fixture: ComponentFixture<HostComponent>;
+  const present = (cls: string) => !!fixture.nativeElement.querySelector(`.${cls}`);
+
+  beforeEach(() => {
+    const { mock: m, providers } = provideMockClerk();
+    mock = m;
+    TestBed.configureTestingModule({ imports: [HostComponent], providers });
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+  });
+
+  it('renders neither branch while Clerk is loading', () => {
+    expect(present('admin')).toBe(false);
+    expect(present('denied')).toBe(false);
+  });
+
+  it('renders the else template when signed out', () => {
+    mock.isLoaded.set(true);
+    fixture.detectChanges();
+
+    expect(present('admin')).toBe(false);
+    expect(present('denied')).toBe(true);
+  });
+
+  it('renders content when the user is authorized', () => {
+    mock.isLoaded.set(true);
+    mock.isSignedIn.set(true);
+    mock.has.mockReturnValue(true);
+    fixture.detectChanges();
+
+    expect(present('admin')).toBe(true);
+    expect(present('denied')).toBe(false);
+    expect(mock.has).toHaveBeenCalledWith({ role: 'org:admin' });
+  });
+
+  it('renders the else template when signed in but unauthorized', () => {
+    mock.isLoaded.set(true);
+    mock.isSignedIn.set(true);
+    mock.has.mockReturnValue(false);
+    fixture.detectChanges();
+
+    expect(present('admin')).toBe(false);
+    expect(present('denied')).toBe(true);
+  });
+});

--- a/projects/ngx-clerk/src/lib/directives/protect.directive.ts
+++ b/projects/ngx-clerk/src/lib/directives/protect.directive.ts
@@ -1,0 +1,71 @@
+import { Directive, EmbeddedViewRef, TemplateRef, ViewContainerRef, effect, inject, input } from '@angular/core';
+import type { CheckAuthorizationWithCustomPermissions } from '@clerk/shared/types';
+import { ClerkService, type CheckAuthorizationParams } from '../services/clerk.service';
+
+/** A `*clerkProtect` condition: an authorization object or a predicate over `has`. */
+export type ClerkProtectCondition =
+  | CheckAuthorizationParams
+  | ((has: CheckAuthorizationWithCustomPermissions) => boolean);
+
+/**
+ * Structural directive that renders its content only when the current user is
+ * authorized. Pass a role/permission/feature/plan object or a predicate. An
+ * optional `else` template is rendered when unauthorized.
+ *
+ * @example
+ * ```html
+ * <section *clerkProtect="{ role: 'org:admin' }">Admin only</section>
+ *
+ * <section *clerkProtect="{ permission: 'org:posts:manage' }; else noAccess">
+ *   Manage posts
+ * </section>
+ * <ng-template #noAccess>You do not have access.</ng-template>
+ * ```
+ */
+@Directive({ selector: '[clerkProtect]', standalone: true })
+export class ClerkProtectDirective {
+  private readonly _clerk = inject(ClerkService);
+  private readonly _templateRef = inject<TemplateRef<unknown>>(TemplateRef);
+  private readonly _viewContainer = inject(ViewContainerRef);
+  private _viewRef: EmbeddedViewRef<unknown> | null = null;
+  private _shownTemplate: TemplateRef<unknown> | null = null;
+
+  /** Authorization condition: a role/permission/feature/plan object, or a predicate. */
+  readonly clerkProtect = input<ClerkProtectCondition | undefined>(undefined);
+  /** Template rendered when the user is unauthorized. */
+  readonly clerkProtectElse = input<TemplateRef<unknown> | null>(null);
+
+  constructor() {
+    effect(() => {
+      if (!this._clerk.isLoaded()) {
+        this._render(null);
+        return;
+      }
+      this._render(this._authorized() ? this._templateRef : this.clerkProtectElse());
+    });
+  }
+
+  private _authorized(): boolean {
+    if (!this._clerk.isSignedIn()) {
+      return false;
+    }
+    const condition = this.clerkProtect();
+    if (!condition) {
+      return true;
+    }
+    if (typeof condition === 'function') {
+      const has = ((params: CheckAuthorizationParams) => this._clerk.has(params)) as CheckAuthorizationWithCustomPermissions;
+      return condition(has);
+    }
+    return this._clerk.has(condition);
+  }
+
+  private _render(template: TemplateRef<unknown> | null): void {
+    if (this._shownTemplate === template) {
+      return;
+    }
+    this._viewContainer.clear();
+    this._viewRef = template ? this._viewContainer.createEmbeddedView(template) : null;
+    this._shownTemplate = template;
+  }
+}

--- a/projects/ngx-clerk/src/lib/guards/auth.guard.spec.ts
+++ b/projects/ngx-clerk/src/lib/guards/auth.guard.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+import { canActivateClerk, canActivateProtect } from './auth.guard';
+import { MockClerkService, provideMockClerk } from '../testing/mock-clerk';
+
+describe('auth guards', () => {
+  let mock: MockClerkService;
+  let routerMock: { parseUrl: ReturnType<typeof vi.fn> };
+  const state = { url: '/dashboard' } as RouterStateSnapshot;
+  const route = {} as ActivatedRouteSnapshot;
+
+  beforeEach(() => {
+    const { mock: m, providers } = provideMockClerk();
+    mock = m;
+    routerMock = { parseUrl: vi.fn((url: string) => ({ url })) };
+    TestBed.configureTestingModule({
+      providers: [...providers, { provide: Router, useValue: routerMock }],
+    });
+  });
+
+  const run = (guard: ReturnType<typeof canActivateProtect> | typeof canActivateClerk) =>
+    TestBed.runInInjectionContext(() => guard(route, state));
+
+  describe('canActivateClerk', () => {
+    it('allows signed-in users', () => {
+      mock.isLoaded.set(true);
+      mock.isSignedIn.set(true);
+      expect(run(canActivateClerk)).toBe(true);
+    });
+
+    it('blocks and redirects signed-out users', () => {
+      mock.isLoaded.set(true);
+      mock.isSignedIn.set(false);
+      expect(run(canActivateClerk)).toBe(false);
+      expect(mock.redirectToSignIn).toHaveBeenCalledWith(
+        expect.objectContaining({ signInFallbackRedirectUrl: '/dashboard' }),
+      );
+    });
+  });
+
+  describe('canActivateProtect', () => {
+    it('allows authorized users', () => {
+      mock.isLoaded.set(true);
+      mock.isSignedIn.set(true);
+      mock.has.mockReturnValue(true);
+      expect(run(canActivateProtect({ role: 'org:admin' }))).toBe(true);
+      expect(mock.has).toHaveBeenCalledWith({ role: 'org:admin' });
+    });
+
+    it('blocks unauthorized users with no fallback url', () => {
+      mock.isLoaded.set(true);
+      mock.isSignedIn.set(true);
+      mock.has.mockReturnValue(false);
+      expect(run(canActivateProtect({ role: 'org:admin' }))).toBe(false);
+    });
+
+    it('redirects unauthorized users to unauthorizedUrl', () => {
+      mock.isLoaded.set(true);
+      mock.isSignedIn.set(true);
+      mock.has.mockReturnValue(false);
+      run(canActivateProtect({ role: 'org:admin' }, { unauthorizedUrl: '/dashboard' }));
+      expect(routerMock.parseUrl).toHaveBeenCalledWith('/dashboard');
+    });
+
+    it('redirects signed-out users to sign-in', () => {
+      mock.isLoaded.set(true);
+      mock.isSignedIn.set(false);
+      expect(run(canActivateProtect({ role: 'org:admin' }))).toBe(false);
+      expect(mock.redirectToSignIn).toHaveBeenCalled();
+    });
+  });
+});

--- a/projects/ngx-clerk/src/lib/guards/auth.guard.ts
+++ b/projects/ngx-clerk/src/lib/guards/auth.guard.ts
@@ -1,8 +1,8 @@
 import { inject } from '@angular/core';
-import { type CanActivateFn, type RouterStateSnapshot } from '@angular/router';
+import { Router, type CanActivateFn, type RouterStateSnapshot, type UrlTree } from '@angular/router';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { filter, map, take } from 'rxjs';
-import { ClerkService } from '../services/clerk.service';
+import { ClerkService, type CheckAuthorizationParams } from '../services/clerk.service';
 
 function checkAuth(clerk: ClerkService, state: RouterStateSnapshot): boolean {
   if (!clerk.isSignedIn()) {
@@ -36,3 +36,57 @@ export const canActivateClerk: CanActivateFn = (_route, state) => {
     map(() => checkAuth(clerk, state)),
   );
 };
+
+/** Options for {@link canActivateProtect}. */
+export interface CanActivateProtectOptions {
+  /** Where to redirect a signed-in but unauthorized user. Defaults to blocking (returns `false`). */
+  unauthorizedUrl?: string;
+}
+
+/**
+ * Creates a route guard that restricts access to users satisfying an
+ * authorization condition (role, permission, feature, or plan). Unauthenticated
+ * users are redirected to sign-in; signed-in-but-unauthorized users are blocked
+ * (or redirected to `unauthorizedUrl`).
+ *
+ * @example
+ * ```ts
+ * const routes: Routes = [
+ *   {
+ *     path: 'admin',
+ *     component: AdminComponent,
+ *     canActivate: [canActivateProtect({ role: 'org:admin' }, { unauthorizedUrl: '/dashboard' })],
+ *   },
+ * ];
+ * ```
+ */
+export function canActivateProtect(
+  params: CheckAuthorizationParams,
+  options: CanActivateProtectOptions = {},
+): CanActivateFn {
+  return (_route, state) => {
+    const clerk = inject(ClerkService);
+    const router = inject(Router);
+
+    const check = (): boolean | UrlTree => {
+      if (!clerk.isSignedIn()) {
+        clerk.redirectToSignIn({ signInFallbackRedirectUrl: state.url });
+        return false;
+      }
+      if (clerk.has(params)) {
+        return true;
+      }
+      return options.unauthorizedUrl ? router.parseUrl(options.unauthorizedUrl) : false;
+    };
+
+    if (clerk.isLoaded()) {
+      return check();
+    }
+
+    return toObservable(clerk.isLoaded).pipe(
+      filter((loaded) => loaded),
+      take(1),
+      map(() => check()),
+    );
+  };
+}

--- a/projects/ngx-clerk/src/lib/provider.spec.ts
+++ b/projects/ngx-clerk/src/lib/provider.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { APP_INITIALIZER } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { CLERK_OPTIONS, provideClerk } from './provider';
+import { ClerkService } from './services/clerk.service';
+
+describe('provideClerk', () => {
+  it('registers the Clerk options token', () => {
+    TestBed.configureTestingModule({
+      providers: [provideRouter([]), provideClerk({ publishableKey: 'pk_test_x' })],
+    });
+
+    expect(TestBed.inject(CLERK_OPTIONS)).toEqual(expect.objectContaining({ publishableKey: 'pk_test_x' }));
+  });
+
+  it('initializes ClerkService via an APP_INITIALIZER, injecting SDK metadata', () => {
+    const initSpy = vi.spyOn(ClerkService.prototype, 'initialize').mockResolvedValue(undefined);
+    TestBed.configureTestingModule({
+      providers: [provideRouter([]), provideClerk({ publishableKey: 'pk_test_x' })],
+    });
+
+    const initializers = TestBed.inject(APP_INITIALIZER);
+    initializers.forEach((init) => init());
+
+    expect(initSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publishableKey: 'pk_test_x',
+        sdkMetadata: expect.objectContaining({ name: 'ngx-clerk' }),
+      }),
+    );
+  });
+});

--- a/projects/ngx-clerk/src/lib/services/clerk.service.spec.ts
+++ b/projects/ngx-clerk/src/lib/services/clerk.service.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { ClerkService } from './clerk.service';
+import { createMockClerkInstance, MockClerkInstance } from '../testing/mock-clerk';
+
+// Avoid loading real ClerkJS from the CDN during tests by stubbing the shared loader.
+vi.mock('@clerk/shared/loadClerkJsScript', () => ({
+  loadClerkJSScript: vi.fn().mockResolvedValue(null),
+  loadClerkUIScript: vi.fn().mockResolvedValue(undefined),
+}));
+
+type ResourceListener = (resources: Record<string, unknown>) => void;
+
+describe('ClerkService', () => {
+  let instance: MockClerkInstance;
+  let listeners: ResourceListener[];
+
+  beforeEach(() => {
+    listeners = [];
+    instance = createMockClerkInstance();
+    instance['addListener'] = vi.fn((cb: ResourceListener) => {
+      listeners.push(cb);
+      return () => undefined;
+    });
+    window.Clerk = instance as unknown as Window['Clerk'];
+    (window as unknown as { __internal_ClerkUICtor: unknown }).__internal_ClerkUICtor = class {};
+    TestBed.configureTestingModule({ providers: [provideRouter([])] });
+  });
+
+  afterEach(() => {
+    delete (window as { Clerk?: unknown }).Clerk;
+    vi.restoreAllMocks();
+  });
+
+  async function initService(): Promise<ClerkService> {
+    const service = TestBed.inject(ClerkService);
+    await service.initialize({ publishableKey: 'pk_test_x' });
+    return service;
+  }
+
+  const emit = (resources: Record<string, unknown>) => listeners.forEach((cb) => cb(resources));
+
+  it('is not loaded before initialize', () => {
+    const service = TestBed.inject(ClerkService);
+    expect(service.isLoaded()).toBe(false);
+    expect(service.isSignedIn()).toBe(false);
+  });
+
+  it('loads ClerkJS and reflects the signed-out state', async () => {
+    const service = await initService();
+
+    expect(instance['load']).toHaveBeenCalled();
+    expect(service.isLoaded()).toBe(true);
+    expect(service.isSignedIn()).toBe(false);
+    expect(service.user()).toBeNull();
+  });
+
+  it('reflects signed-in resources after a listener emission', async () => {
+    const service = await initService();
+    const session = { id: 'sess_1', status: 'active', lastActiveToken: { jwt: { claims: {} } }, factorVerificationAge: null };
+    emit({ client: { sessions: [session] }, session, user: { id: 'user_1', organizationMemberships: [] }, organization: null });
+
+    expect(service.isSignedIn()).toBe(true);
+    expect(service.userId()).toBe('user_1');
+    expect(service.sessionId()).toBe('sess_1');
+  });
+
+  it('delegates UI and session methods to the Clerk instance', async () => {
+    const service = await initService();
+    service.openSignIn();
+    service.signOut({ redirectUrl: '/bye' });
+    service.setActive({ session: null });
+
+    expect(instance['openSignIn']).toHaveBeenCalled();
+    expect(instance['signOut']).toHaveBeenCalledWith({ redirectUrl: '/bye' });
+    expect(instance['setActive']).toHaveBeenCalledWith({ session: null });
+  });
+
+  it('getToken returns null when signed out and the token when signed in', async () => {
+    const service = await initService();
+    expect(await service.getToken()).toBeNull();
+
+    const session = {
+      id: 'sess_1',
+      status: 'active',
+      lastActiveToken: { jwt: { claims: {} } },
+      factorVerificationAge: null,
+      getToken: vi.fn().mockResolvedValue('jwt-token'),
+    };
+    emit({ client: {}, session, user: { id: 'user_1', organizationMemberships: [] }, organization: null });
+
+    expect(await service.getToken()).toBe('jwt-token');
+  });
+
+  it('has() returns false when signed out', async () => {
+    const service = await initService();
+    expect(service.has({ role: 'org:admin' })).toBe(false);
+  });
+
+  it('has() evaluates organization roles and permissions from claims', async () => {
+    const service = await initService();
+    const organization = { id: 'org_1', slug: 'acme' };
+    const user = {
+      id: 'user_1',
+      organizationMemberships: [
+        { organization: { id: 'org_1' }, role: 'org:admin', permissions: ['org:posts:manage'] },
+      ],
+    };
+    const session = { id: 'sess_1', status: 'active', lastActiveToken: { jwt: { claims: { fea: '', pla: '' } } }, factorVerificationAge: null };
+    emit({ client: {}, session, user, organization });
+
+    expect(service.orgRole()).toBe('org:admin');
+    expect(service.has({ role: 'org:admin' })).toBe(true);
+    expect(service.has({ role: 'org:member' })).toBe(false);
+    expect(service.has({ permission: 'org:posts:manage' })).toBe(true);
+  });
+});

--- a/projects/ngx-clerk/src/lib/services/clerk.service.ts
+++ b/projects/ngx-clerk/src/lib/services/clerk.service.ts
@@ -1,18 +1,30 @@
 import { Injectable, NgZone, PLATFORM_ID, computed, inject, signal } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { Router } from '@angular/router';
+import { deriveState } from '@clerk/shared/deriveState';
+import { createCheckAuthorization } from '@clerk/shared/authorization';
 import type {
   ActiveSessionResource,
+  CheckAuthorizationWithCustomPermissions,
   Clerk,
   ClerkOptions,
   ClientResource,
   CreateOrganizationProps,
+  GetTokenOptions,
+  HandleOAuthCallbackParams,
+  JwtPayload,
+  OrganizationMembershipResource,
   OrganizationProfileProps,
   OrganizationResource,
+  SessionResource,
+  SetActiveParams,
   SignInProps,
   SignInRedirectOptions,
+  SignInResource,
+  SignOutOptions,
   SignUpProps,
   SignUpRedirectOptions,
+  SignUpResource,
   UserProfileProps,
   UserResource,
   Without,
@@ -35,6 +47,15 @@ declare global {
   interface Window {
     Clerk: HeadlessBrowserClerk | BrowserClerk;
   }
+}
+
+/** The authorization parameters accepted by {@link ClerkService.has}. */
+export type CheckAuthorizationParams = Parameters<CheckAuthorizationWithCustomPermissions>[0];
+
+/** Options accepted by {@link ClerkService.updateClerkOptions}. */
+export interface ClerkUpdateOptions {
+  localization?: ClerkOptions['localization'];
+  appearance?: ClerkOptions['appearance'];
 }
 
 /**
@@ -85,6 +106,69 @@ export class ClerkService {
   readonly userId = computed(() => this._user()?.id ?? null);
   /** The current active organization's ID, or `null` if none is active. */
   readonly orgId = computed(() => this._organization()?.id ?? null);
+
+  /**
+   * Auth state derived from the current Clerk resources, built from the cached
+   * session JWT claims.
+   */
+  private readonly _derivedState = computed(() =>
+    deriveState(
+      this.isLoaded(),
+      {
+        client: this._client(),
+        session: this._session(),
+        user: this._user(),
+        organization: this._organization(),
+      } as Parameters<typeof deriveState>[1],
+      undefined,
+    ),
+  );
+
+  /** The active session's ID, or `null` if not signed in. */
+  readonly sessionId = computed(() => this._derivedState().sessionId ?? null);
+  /** The current user's role in the active organization, or `null`. */
+  readonly orgRole = computed(() => this._derivedState().orgRole ?? null);
+  /** The active organization's slug, or `null`. */
+  readonly orgSlug = computed(() => this._derivedState().orgSlug ?? null);
+  /** The claims of the active session's JWT, or `null`. */
+  readonly sessionClaims = computed(() => this._derivedState().sessionClaims ?? null);
+  /** The actor (impersonation) claim of the active session, or `null`. */
+  readonly actor = computed(() => this._derivedState().actor ?? null);
+
+  /** The active sign-in attempt resource, or `null`. */
+  readonly signIn = computed<SignInResource | null>(() => this._client()?.signIn ?? null);
+  /** The active sign-up attempt resource, or `null`. */
+  readonly signUp = computed<SignUpResource | null>(() => this._client()?.signUp ?? null);
+  /** All sessions registered on the current client device. */
+  readonly sessions = computed<SessionResource[]>(() => this._client()?.sessions ?? []);
+
+  /** The current user's membership in the active organization, or `null`. */
+  readonly membership = computed<OrganizationMembershipResource | null>(() => {
+    const orgId = this.orgId();
+    const user = this._user();
+    if (!orgId || !user) {
+      return null;
+    }
+    return user.organizationMemberships?.find((m) => m.organization.id === orgId) ?? null;
+  });
+
+  /**
+   * The authorization checker for the current session, built from the cached
+   * JWT claims. Returns `false` while signed out.
+   */
+  private readonly _checkAuthorization = computed<CheckAuthorizationWithCustomPermissions>(() => {
+    const d = this._derivedState();
+    const claims = d.sessionClaims as (JwtPayload & { fea?: string; pla?: string }) | null | undefined;
+    return createCheckAuthorization({
+      userId: d.userId,
+      orgId: d.orgId,
+      orgRole: d.orgRole,
+      orgPermissions: d.orgPermissions,
+      factorVerificationAge: d.factorVerificationAge,
+      features: claims?.fea || '',
+      plans: claims?.pla || '',
+    });
+  });
 
   /**
    * Initialize ClerkJS. Called internally by provideClerk() via APP_INITIALIZER.
@@ -143,22 +227,64 @@ export class ClerkService {
     });
   }
 
+  // --- Authorization & Tokens ---
+
+  /**
+   * Checks whether the current user satisfies an authorization condition
+   * (role, permission, feature, or plan). Returns `false` while signed out.
+   *
+   * @example
+   * ```ts
+   * if (clerk.has({ role: 'org:admin' })) { ... }
+   * if (clerk.has({ permission: 'org:posts:manage' })) { ... }
+   * ```
+   */
+  has(params: CheckAuthorizationParams): boolean {
+    return this._checkAuthorization()(params);
+  }
+
+  /**
+   * Returns the current session token (JWT), optionally for a named template.
+   * Resolves to `null` when there is no active session.
+   */
+  getToken(options?: GetTokenOptions): Promise<string | null> {
+    const session = this._session();
+    if (!session) {
+      return Promise.resolve(null);
+    }
+    return session.getToken(options);
+  }
+
+  /** Sets the active session and/or organization. */
+  setActive(params: SetActiveParams): Promise<void> {
+    return this.clerk()?.setActive(params) ?? Promise.resolve();
+  }
+
+  /** Completes an OAuth/SSO redirect flow by handling the callback. */
+  async handleRedirectCallback(params?: HandleOAuthCallbackParams): Promise<void> {
+    await this.clerk()?.handleRedirectCallback(params ?? {});
+  }
+
   // --- Appearance & Localization ---
 
   /** Updates the global appearance configuration for all Clerk components. */
   updateAppearance(opts: ClerkOptions['appearance']) {
-    const clerkInstance = this.clerk();
-    if (clerkInstance) {
-      clerkInstance.__internal_updateProps({ appearance: opts });
-    }
+    this.clerk()?.__internal_updateProps({ appearance: opts });
   }
 
   /** Updates the localization configuration for all Clerk components. */
   updateLocalization(opts: ClerkOptions['localization']) {
-    const clerkInstance = this.clerk();
-    if (clerkInstance) {
-      clerkInstance.__internal_updateProps({ localization: opts });
-    }
+    this.clerk()?.__internal_updateProps({ options: { localization: opts } });
+  }
+
+  /**
+   * Updates Clerk's global options (localization and/or appearance) at runtime.
+   */
+  updateClerkOptions(options: ClerkUpdateOptions) {
+    this.clerk()?.__internal_updateProps({
+      options: { localization: options.localization },
+      appearance: options.appearance,
+    });
   }
 
   // --- Open / Close UI ---
@@ -228,7 +354,7 @@ export class ClerkService {
   // --- Sign Out ---
 
   /** Signs out the current user. */
-  signOut(opts?: Parameters<Clerk['signOut']>[0]) {
+  signOut(opts?: SignOutOptions) {
     return this.clerk()?.signOut(opts) ?? Promise.resolve();
   }
 }

--- a/projects/ngx-clerk/src/lib/testing/mock-clerk.ts
+++ b/projects/ngx-clerk/src/lib/testing/mock-clerk.ts
@@ -1,0 +1,115 @@
+import { Provider, WritableSignal, signal } from '@angular/core';
+import { Mock, vi } from 'vitest';
+import { ClerkService } from '../services/clerk.service';
+
+/** Mock state used to seed a fake Clerk instance. */
+export interface MockClerkState {
+  client?: unknown;
+  session?: unknown;
+  user?: unknown;
+  organization?: unknown;
+}
+
+const INSTANCE_METHODS = [
+  'mountSignIn', 'unmountSignIn', 'mountSignUp', 'unmountSignUp',
+  'mountUserProfile', 'unmountUserProfile', 'mountUserButton', 'unmountUserButton',
+  'mountUserAvatar', 'unmountUserAvatar', 'mountOrganizationProfile', 'unmountOrganizationProfile',
+  'mountOrganizationSwitcher', 'unmountOrganizationSwitcher', 'mountCreateOrganization', 'unmountCreateOrganization',
+  'mountOrganizationList', 'unmountOrganizationList', 'mountWaitlist', 'unmountWaitlist',
+  'mountPricingTable', 'unmountPricingTable',
+  'openSignIn', 'closeSignIn', 'openSignUp', 'closeSignUp', 'openUserProfile', 'closeUserProfile',
+  'openOrganizationProfile', 'closeOrganizationProfile', 'openCreateOrganization', 'closeCreateOrganization',
+  'openGoogleOneTap', 'closeGoogleOneTap', 'redirectToSignIn', 'redirectToSignUp', '__internal_updateProps',
+] as const;
+
+/** A fake `window.Clerk`-style instance whose methods are all spies. */
+export type MockClerkInstance = Record<string, Mock> & {
+  client: unknown;
+  session: unknown;
+  user: unknown;
+  organization: unknown;
+};
+
+/** Creates a fake `window.Clerk`-style instance with every method spied. */
+export function createMockClerkInstance(state: MockClerkState = {}): MockClerkInstance {
+  const instance: Record<string, unknown> = {
+    client: state.client ?? null,
+    session: state.session ?? null,
+    user: state.user ?? null,
+    organization: state.organization ?? null,
+    load: vi.fn().mockResolvedValue(undefined),
+    addListener: vi.fn(),
+    signOut: vi.fn().mockResolvedValue(undefined),
+    setActive: vi.fn().mockResolvedValue(undefined),
+    handleRedirectCallback: vi.fn().mockResolvedValue(undefined),
+  };
+  for (const method of INSTANCE_METHODS) {
+    if (!instance[method]) {
+      instance[method] = vi.fn();
+    }
+  }
+  return instance as MockClerkInstance;
+}
+
+/** A fake {@link ClerkService} with writable signals and spied methods for tests. */
+export interface MockClerkService {
+  clerk: WritableSignal<MockClerkInstance | null>;
+  client: WritableSignal<unknown>;
+  session: WritableSignal<unknown>;
+  user: WritableSignal<unknown>;
+  organization: WritableSignal<unknown>;
+  isLoaded: WritableSignal<boolean>;
+  isSignedIn: WritableSignal<boolean>;
+  has: Mock;
+  getToken: Mock;
+  setActive: Mock;
+  handleRedirectCallback: Mock;
+  openSignIn: Mock;
+  closeSignIn: Mock;
+  openSignUp: Mock;
+  closeSignUp: Mock;
+  redirectToSignIn: Mock;
+  redirectToSignUp: Mock;
+  signOut: Mock;
+  updateClerkOptions: Mock;
+  updateAppearance: Mock;
+  updateLocalization: Mock;
+  instance: MockClerkInstance;
+}
+
+/** Creates a fake {@link ClerkService} for directive/component/guard tests. */
+export function createMockClerkService(): MockClerkService {
+  return {
+    clerk: signal<MockClerkInstance | null>(null),
+    client: signal<unknown>(null),
+    session: signal<unknown>(null),
+    user: signal<unknown>(null),
+    organization: signal<unknown>(null),
+    isLoaded: signal(false),
+    isSignedIn: signal(false),
+    has: vi.fn().mockReturnValue(false),
+    getToken: vi.fn().mockResolvedValue(null),
+    setActive: vi.fn().mockResolvedValue(undefined),
+    handleRedirectCallback: vi.fn().mockResolvedValue(undefined),
+    openSignIn: vi.fn(),
+    closeSignIn: vi.fn(),
+    openSignUp: vi.fn(),
+    closeSignUp: vi.fn(),
+    redirectToSignIn: vi.fn(),
+    redirectToSignUp: vi.fn(),
+    signOut: vi.fn().mockResolvedValue(undefined),
+    updateClerkOptions: vi.fn(),
+    updateAppearance: vi.fn(),
+    updateLocalization: vi.fn(),
+    instance: createMockClerkInstance(),
+  };
+}
+
+/** Returns a provider that supplies a {@link MockClerkService} for {@link ClerkService}. */
+export function provideMockClerk(): { mock: MockClerkService; providers: Provider[] } {
+  const mock = createMockClerkService();
+  return {
+    mock,
+    providers: [{ provide: ClerkService, useValue: mock as unknown as ClerkService }],
+  };
+}

--- a/projects/ngx-clerk/src/lib/utils/loadClerkJsScript.ts
+++ b/projects/ngx-clerk/src/lib/utils/loadClerkJsScript.ts
@@ -36,7 +36,7 @@ export const loadClerkScripts = (opts: ClerkInitOptions): { clerkPromise: Promis
 
   const uiOpts = { publishableKey, proxyUrl: opts.proxyUrl, domain: opts.domain, nonce: opts.nonce };
 
-  // Fire both downloads in parallel (same approach as Vue SDK)
+  // Fire both ClerkJS and ClerkUI downloads in parallel
   const clerkPromise = loadClerkJSScriptShared(scriptOpts).catch(() => {
     throw new Error(FAILED_TO_LOAD_ERROR);
   });

--- a/projects/ngx-clerk/src/lib/utils/mount.spec.ts
+++ b/projects/ngx-clerk/src/lib/utils/mount.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { clerkPropsEqual } from './mount';
+
+describe('clerkPropsEqual', () => {
+  it('treats structurally equal objects as equal', () => {
+    expect(clerkPropsEqual({ a: 1, b: 'x' }, { a: 1, b: 'x' })).toBe(true);
+  });
+
+  it('detects content changes', () => {
+    expect(clerkPropsEqual({ a: 1 }, { a: 2 })).toBe(false);
+  });
+
+  it('ignores function identity', () => {
+    expect(clerkPropsEqual({ fn: () => 1 }, { fn: () => 2 })).toBe(true);
+  });
+
+  it('treats undefined as equal to undefined', () => {
+    expect(clerkPropsEqual(undefined, undefined)).toBe(true);
+  });
+
+  it('distinguishes undefined from a value', () => {
+    expect(clerkPropsEqual(undefined, { a: 1 })).toBe(false);
+  });
+});

--- a/projects/ngx-clerk/src/lib/utils/mount.ts
+++ b/projects/ngx-clerk/src/lib/utils/mount.ts
@@ -1,0 +1,79 @@
+import { DestroyRef, effect, inject } from '@angular/core';
+import type { Clerk } from '@clerk/shared/types';
+import { ClerkService } from '../services/clerk.service';
+
+/** Configuration for mounting a ClerkJS UI component onto a host element. */
+export interface ClerkMountConfig<TProps> {
+  /** Returns the host element to mount into (reads a signal). */
+  node: () => HTMLElement | undefined;
+  /** Returns the current props (reads a signal). */
+  props: () => TProps | undefined;
+  /** Mounts the ClerkJS component into the host element. */
+  mount: (clerk: Clerk, node: HTMLDivElement, props?: TProps) => void;
+  /** Unmounts the ClerkJS component from the host element. */
+  unmount: (clerk: Clerk, node: HTMLDivElement) => void;
+}
+
+/**
+ * Wires a ClerkJS mount component into Angular's reactive lifecycle.
+ *
+ * Mounts once the Clerk instance and host element are both available, re-mounts
+ * whenever the props change (so updates after the initial mount take effect),
+ * and unmounts on destroy. Inline object literals that are structurally equal
+ * do not trigger a re-mount. Must be called from an injection context (e.g. a
+ * component constructor).
+ */
+export function mountClerkComponent<TProps>(config: ClerkMountConfig<TProps>): void {
+  const clerkService = inject(ClerkService);
+  const destroyRef = inject(DestroyRef);
+  let mountedNode: HTMLDivElement | null = null;
+  let lastProps: TProps | undefined;
+  let hasMounted = false;
+
+  effect(() => {
+    const clerk = clerkService.clerk();
+    const node = config.node() as HTMLDivElement | undefined;
+    const props = config.props();
+    if (!clerk || !node) {
+      return;
+    }
+    if (hasMounted && mountedNode === node && clerkPropsEqual(props, lastProps)) {
+      return;
+    }
+    if (mountedNode) {
+      config.unmount(clerk, mountedNode);
+    }
+    config.mount(clerk, node, props);
+    mountedNode = node;
+    lastProps = props;
+    hasMounted = true;
+  });
+
+  destroyRef.onDestroy(() => {
+    const clerk = clerkService.clerk();
+    if (clerk && mountedNode) {
+      config.unmount(clerk, mountedNode);
+      mountedNode = null;
+    }
+  });
+}
+
+/**
+ * Structural equality check for Clerk component props. Treats functions as
+ * equal-by-token so inline object literals in templates do not trigger needless
+ * re-mounts.
+ */
+export function clerkPropsEqual<T>(a: T, b: T): boolean {
+  if (Object.is(a, b)) {
+    return true;
+  }
+  return stableStringify(a) === stableStringify(b);
+}
+
+function stableStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, (_key, val) => (typeof val === 'function' ? '__fn__' : val)) ?? 'undefined';
+  } catch {
+    return '__unserializable__';
+  }
+}

--- a/projects/ngx-clerk/src/lib/utils/route-utils.spec.ts
+++ b/projects/ngx-clerk/src/lib/utils/route-utils.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { UrlSegment } from '@angular/router';
+import { catchAllRoute } from './route-utils';
+
+describe('catchAllRoute', () => {
+  const seg = (path: string) => new UrlSegment(path, {});
+
+  it('matches a URL whose first segment starts with the path', () => {
+    const matcher = catchAllRoute('sign-in');
+    const url = [seg('sign-in'), seg('factor-one')];
+    expect(matcher(url)).toEqual({ consumed: url });
+  });
+
+  it('returns null when the first segment does not match', () => {
+    const matcher = catchAllRoute('sign-in');
+    expect(matcher([seg('dashboard')])).toBeNull();
+  });
+
+  it('returns null for an empty URL', () => {
+    const matcher = catchAllRoute('sign-in');
+    expect(matcher([])).toBeNull();
+  });
+});

--- a/projects/ngx-clerk/src/public-api.ts
+++ b/projects/ngx-clerk/src/public-api.ts
@@ -3,25 +3,62 @@ export { provideClerk, CLERK_OPTIONS } from './lib/provider';
 
 // Services
 export { ClerkService } from './lib/services/clerk.service';
+export type { CheckAuthorizationParams, ClerkUpdateOptions } from './lib/services/clerk.service';
 
 // Guards
-export { canActivateClerk } from './lib/guards/auth.guard';
+export { canActivateClerk, canActivateProtect } from './lib/guards/auth.guard';
+export type { CanActivateProtectOptions } from './lib/guards/auth.guard';
 
-// Components
+// UI Components
 export { ClerkSignInComponent } from './lib/components/sign-in.component';
 export { ClerkSignUpComponent } from './lib/components/sign-up.component';
 export { ClerkUserProfileComponent } from './lib/components/user-profile.component';
 export { ClerkUserButtonComponent } from './lib/components/user-button.component';
+export { ClerkUserAvatarComponent } from './lib/components/user-avatar.component';
 export { ClerkOrganizationProfileComponent } from './lib/components/organization-profile.component';
 export { ClerkOrganizationSwitcherComponent } from './lib/components/organization-switcher.component';
 export { ClerkCreateOrganizationComponent } from './lib/components/create-organization.component';
 export { ClerkOrganizationListComponent } from './lib/components/organization-list.component';
 export { ClerkWaitlistComponent } from './lib/components/waitlist.component';
-export { ClerkUserAvatarComponent } from './lib/components/user-avatar.component';
 export { ClerkPricingTableComponent } from './lib/components/pricing-table.component';
+export { ClerkGoogleOneTapComponent } from './lib/components/google-one-tap.component';
+export { ClerkAuthenticateWithRedirectCallbackComponent } from './lib/components/authenticate-with-redirect-callback.component';
+
+// Control-flow directives
+export {
+  ClerkSignedInDirective,
+  ClerkSignedOutDirective,
+  ClerkLoadedDirective,
+  ClerkLoadingDirective,
+} from './lib/directives/control-flow.directive';
+
+// Authorization directive
+export { ClerkProtectDirective } from './lib/directives/protect.directive';
+export type { ClerkProtectCondition } from './lib/directives/protect.directive';
+
+// Button directives
+export {
+  ClerkSignInButtonDirective,
+  ClerkSignUpButtonDirective,
+  ClerkSignOutButtonDirective,
+} from './lib/directives/button.directives';
+export type { ClerkButtonMode } from './lib/directives/button.directives';
 
 // Utils
 export { catchAllRoute } from './lib/utils/route-utils';
+
+// Errors (runtime classes + type guards, re-exported from @clerk/shared)
+export {
+  ClerkAPIResponseError,
+  ClerkOfflineError,
+  ClerkRuntimeError,
+  EmailLinkErrorCodeStatus,
+  isClerkAPIResponseError,
+  isClerkRuntimeError,
+  isEmailLinkError,
+  isKnownError,
+  isMetamaskError,
+} from '@clerk/shared/error';
 
 // Types
 export type { ClerkInitOptions } from './lib/utils/types';

--- a/projects/ngx-clerk/tsconfig.spec.json
+++ b/projects/ngx-clerk/tsconfig.spec.json
@@ -2,14 +2,11 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../out-tsc/lib",
-    "declaration": true,
-    "declarationMap": true,
-    "inlineSources": true,
-    "types": [],
+    "outDir": "../../out-tsc/spec",
+    "types": []
   },
-  "exclude": [
+  "include": [
     "**/*.spec.ts",
-    "**/testing/**"
+    "**/*.d.ts"
   ]
 }

--- a/release.config.js
+++ b/release.config.js
@@ -10,13 +10,13 @@ module.exports = {
       changelogFile: 'CHANGELOG.md',
     }],
     ['@semantic-release/exec', {
-      prepareCmd: 'npm version ${nextRelease.version} --no-git-tag-version --prefix projects/ngx-clerk && pnpm build',
+      prepareCmd: 'npm version ${nextRelease.version} --no-git-tag-version --prefix projects/ngx-clerk && node scripts/sync-sdk-version.mjs && pnpm build',
     }],
     ['@semantic-release/npm', {
       pkgRoot: 'dist/ngx-clerk',
     }],
     ['@semantic-release/git', {
-      assets: ['CHANGELOG.md', 'projects/ngx-clerk/package.json'],
+      assets: ['CHANGELOG.md', 'projects/ngx-clerk/package.json', 'projects/ngx-clerk/src/lib/provider.ts'],
       message: 'chore(release): ${nextRelease.version}',
     }],
     '@semantic-release/github',

--- a/scripts/sync-sdk-version.mjs
+++ b/scripts/sync-sdk-version.mjs
@@ -1,0 +1,23 @@
+// Keeps the SDK metadata version in provider.ts in sync with the library's
+// package.json version. Run during the semantic-release prepare step, after the
+// package.json version has been bumped, so the published bundle reports the
+// correct version in its telemetry.
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const pkgPath = 'projects/ngx-clerk/package.json';
+const providerPath = 'projects/ngx-clerk/src/lib/provider.ts';
+
+const { version } = JSON.parse(readFileSync(pkgPath, 'utf8'));
+const source = readFileSync(providerPath, 'utf8');
+
+const updated = source.replace(
+  /(NGX_CLERK_SDK_METADATA[\s\S]*?version:\s*')[^']*(')/,
+  `$1${version}$2`,
+);
+
+if (updated === source && !source.includes(`version: '${version}'`)) {
+  throw new Error(`Could not update SDK metadata version in ${providerPath}`);
+}
+
+writeFileSync(providerPath, updated);
+console.log(`Synced SDK metadata version to ${version}`);


### PR DESCRIPTION
Brings `ngx-clerk` up to Core 3 feature parity with the other Clerk SDKs so it's ready for a public release.

## What this adds

**Authorization**
- `ClerkService.has({ role | permission | feature | plan })` for imperative checks
- `*clerkProtect="… ; else …"` structural directive
- `canActivateProtect({ role | permission }, { unauthorizedUrl })` route-guard factory, alongside the existing `canActivateClerk`

**Control-flow directives**
- `*clerkSignedIn`, `*clerkSignedOut`, `*clerkLoaded`, `*clerkLoading` — idiomatic replacements for the raw `@if (clerk.isSignedIn())` pattern

**Auth actions & tokens**
- `clerkSignInButton` / `clerkSignUpButton` / `clerkSignOutButton` attribute directives (modal + redirect modes)
- `getToken()`, `setActive()`, and `handleRedirectCallback()` on `ClerkService`
- `<clerk-google-one-tap>` and `<clerk-authenticate-with-redirect-callback>` components

**State**
- New `ClerkService` signals: `sessionId`, `orgRole`, `orgSlug`, `sessionClaims`, `actor`, `signIn`, `signUp`, `sessions`, `membership`
- Runtime error classes/guards re-exported (`ClerkAPIResponseError`, `isClerkAPIResponseError`, …)

**Bug fix**
- Mount components now react to `[props]` changes after init — previously props were read once at mount and never updated. The 11 UI components now share a single mount helper that re-mounts on real prop changes.

**Demo**
- New pages covering session tokens, role-gating, multi-session switching, billing, waitlist, Google One Tap, and an `/sso-callback` route; plus a sign-out control.

## Usage

```html
<button *clerkSignedOut clerkSignInButton>Sign in</button>

<section *clerkProtect="{ role: 'org:admin' }; else noAccess">Admins only</section>
<ng-template #noAccess>You do not have access.</ng-template>
```

```ts
const token = await clerk.getToken();
```

## Notes

SSR remains unsupported and is documented as a known limitation. Deferred to a follow-up: custom pages/menu items, experimental billing buttons, `APIKeys`/`OAuthConsent`, `PortalProvider`, and web3/Metamask.
