### PR TITLE
docs(site): Add GitHub Pages documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'website/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: website
+      - run: bundle exec jekyll build --baseurl "/ngx-clerk"
+        env:
+          JEKYLL_ENV: production
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/_site
+
+  deploy:
+    name: Deploy
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,0 +1,6 @@
+_site/
+.jekyll-cache/
+.jekyll-metadata
+.bundle/
+vendor/
+Gemfile.lock

--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "just-the-docs", "~> 0.10.0"
+gem "webrick", "~> 1.8"

--- a/website/_config.yml
+++ b/website/_config.yml
@@ -1,0 +1,25 @@
+title: ngx-clerk
+description: Unofficial Clerk SDK for Angular (Core 3)
+theme: just-the-docs
+
+# Project site lives at https://anagstef.github.io/ngx-clerk/
+# The base path is injected at build time by the GitHub Pages workflow.
+url: https://anagstef.github.io
+
+color_scheme: dark
+search_enabled: true
+heading_anchors: true
+
+aux_links:
+  GitHub:
+    - https://github.com/anagstef/ngx-clerk
+  npm:
+    - https://www.npmjs.com/package/ngx-clerk
+aux_links_new_tab: true
+
+footer_content: "Unofficial, community-maintained &middot; not affiliated with Clerk.com"
+
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - vendor

--- a/website/authentication.md
+++ b/website/authentication.md
@@ -1,0 +1,89 @@
+---
+title: Authentication
+nav_order: 3
+---
+
+# Authentication
+
+## Sign-in and sign-up pages
+
+ngx-clerk renders Clerk's prebuilt UI. Mount the sign-in component on a **catch-all route** so Clerk can handle its sub-routes (e.g. `/sign-in/factor-one`):
+
+```ts
+// src/app/sign-in.component.ts
+import { Component } from '@angular/core';
+import { ClerkSignInComponent } from 'ngx-clerk';
+
+@Component({
+  selector: 'app-sign-in',
+  imports: [ClerkSignInComponent],
+  template: `<clerk-sign-in [props]="{ routing: 'path', path: '/sign-in', signUpUrl: '/sign-up' }" />`,
+})
+export class SignInComponent {}
+```
+
+```ts
+// src/app/app.routes.ts
+import { Routes } from '@angular/router';
+import { catchAllRoute } from 'ngx-clerk';
+
+export const routes: Routes = [
+  {
+    matcher: catchAllRoute('sign-in'),
+    loadComponent: () => import('./sign-in.component').then((m) => m.SignInComponent),
+  },
+  {
+    matcher: catchAllRoute('sign-up'),
+    loadComponent: () => import('./sign-up.component').then((m) => m.SignUpComponent),
+  },
+];
+```
+
+The sign-up page follows the same pattern with `<clerk-sign-up />`.
+
+## Auth buttons
+
+Attribute directives trigger auth actions on your own button — no extra DOM, so you keep full control of styling:
+
+```html
+<button clerkSignInButton>Sign in</button>
+<button clerkSignUpButton mode="modal">Create account</button>
+<button clerkSignOutButton redirectUrl="/">Sign out</button>
+```
+
+`mode="modal"` opens Clerk's modal; the default `redirect` mode navigates to your sign-in/up page.
+
+## Control-flow directives
+
+Render content conditionally on auth state with structural directives — no need to read signals manually:
+
+```html
+<span *clerkLoading>Loading…</span>
+
+<ng-container *clerkLoaded>
+  <clerk-user-button *clerkSignedIn />
+  <button *clerkSignedOut clerkSignInButton>Sign in</button>
+</ng-container>
+```
+
+| Directive | Renders when |
+| --- | --- |
+| `*clerkSignedIn` | a user is signed in |
+| `*clerkSignedOut` | Clerk is loaded and no user is signed in |
+| `*clerkLoaded` | Clerk has finished loading |
+| `*clerkLoading` | Clerk is still loading |
+
+## Google One Tap
+
+```html
+<clerk-google-one-tap />
+```
+
+## OAuth / SSO callback
+
+For custom OAuth flows, render the callback component on your `/sso-callback` route to complete the redirect:
+
+```html
+<clerk-authenticate-with-redirect-callback
+  [props]="{ signInFallbackRedirectUrl: '/dashboard' }" />
+```

--- a/website/index.md
+++ b/website/index.md
@@ -1,0 +1,30 @@
+---
+title: Home
+nav_order: 1
+---
+
+# ngx-clerk
+
+Unofficial Clerk SDK for Angular (Core 3) — drop-in components, a reactive service, structural directives, and route guards for authentication, user management, and organizations.
+
+> **Disclaimer:** This is an unofficial, community-maintained package and is not affiliated with Clerk.com.
+
+## Install
+
+```bash
+npm install ngx-clerk
+```
+
+## Get started
+
+- [Quickstart]({% link quickstart.md %}) — add authentication to a new app in a few steps
+- [Authentication]({% link authentication.md %}) — sign-in/up, auth buttons, and control-flow directives
+- [Protecting routes]({% link protecting-routes.md %}) — guards and the `*clerkProtect` directive
+- [Session tokens]({% link session-tokens.md %}) — call your backend with `getToken()`
+- [Reading auth state]({% link reading-auth-state.md %}) — the `ClerkService` signals
+
+## Requirements
+
+- Angular 19 or higher
+- Clerk Core 3 (ClerkJS v6)
+- Client-side only — Server-Side Rendering (SSR) is not supported yet

--- a/website/protecting-routes.md
+++ b/website/protecting-routes.md
@@ -1,0 +1,61 @@
+---
+title: Protecting routes
+nav_order: 4
+---
+
+# Protecting routes
+
+## Require authentication
+
+Use the `canActivateClerk` guard to restrict a route to signed-in users. It waits for Clerk to load, then redirects unauthenticated users to sign-in:
+
+```ts
+// src/app/app.routes.ts
+import { Routes } from '@angular/router';
+import { canActivateClerk } from 'ngx-clerk';
+
+export const routes: Routes = [
+  {
+    path: 'dashboard',
+    canActivate: [canActivateClerk],
+    loadComponent: () => import('./dashboard.component').then((m) => m.DashboardComponent),
+  },
+];
+```
+
+## Require a role or permission
+
+`canActivateProtect` restricts a route to users that satisfy an authorization condition. Signed-in-but-unauthorized users are blocked, or redirected to `unauthorizedUrl` when provided:
+
+```ts
+import { canActivateProtect } from 'ngx-clerk';
+
+export const routes: Routes = [
+  {
+    path: 'admin',
+    canActivate: [canActivateProtect({ role: 'org:admin' }, { unauthorizedUrl: '/dashboard' })],
+    loadComponent: () => import('./admin.component').then((m) => m.AdminComponent),
+  },
+];
+```
+
+## Gate UI with `*clerkProtect`
+
+Protect part of a template by role, permission, feature, or plan. An optional `else` template renders when the user is unauthorized:
+
+```html
+<section *clerkProtect="{ role: 'org:admin' }; else noAccess">
+  Admins only
+</section>
+<ng-template #noAccess>You do not have access.</ng-template>
+```
+
+## Check authorization imperatively
+
+`ClerkService.has()` returns a boolean for the same conditions:
+
+```ts
+if (clerk.has({ permission: 'org:posts:manage' })) {
+  // …
+}
+```

--- a/website/quickstart.md
+++ b/website/quickstart.md
@@ -1,0 +1,121 @@
+---
+title: Quickstart
+nav_order: 2
+---
+
+# Quickstart
+
+Add authentication to a new Angular app with ngx-clerk.
+
+## Before you start
+
+- [Create a Clerk application](https://dashboard.clerk.com/) in the Clerk Dashboard and copy your **Publishable Key**.
+- This guide assumes a standalone Angular 19+ app with the router.
+
+## Create a new Angular app
+
+```bash
+ng new my-app --routing --style=css
+cd my-app
+```
+
+## Install ngx-clerk
+
+```bash
+npm install ngx-clerk
+```
+
+## Set your Clerk Publishable Key
+
+Add your key to the environment file:
+
+```ts
+// src/environments/environment.ts
+export const environment = {
+  clerkPublishableKey: 'pk_test_XXXXXXXX',
+};
+```
+
+## Add `provideClerk` to your app
+
+Register Clerk in your application config with your Publishable Key:
+
+```ts
+// src/app/app.config.ts
+import { ApplicationConfig } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { provideClerk } from 'ngx-clerk';
+import { routes } from './app.routes';
+import { environment } from '../environments/environment';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideRouter(routes),
+    provideClerk({ publishableKey: environment.clerkPublishableKey }),
+  ],
+};
+```
+
+## Add Clerk components
+
+Use the control-flow directives and the user button to build a header that reacts to auth state:
+
+```ts
+// src/app/app.component.ts
+import { Component } from '@angular/core';
+import { RouterLink, RouterOutlet } from '@angular/router';
+import {
+  ClerkSignedInDirective,
+  ClerkSignedOutDirective,
+  ClerkUserButtonComponent,
+} from 'ngx-clerk';
+
+@Component({
+  selector: 'app-root',
+  imports: [RouterOutlet, RouterLink, ClerkSignedInDirective, ClerkSignedOutDirective, ClerkUserButtonComponent],
+  template: `
+    <header>
+      <a *clerkSignedOut routerLink="/sign-in">Sign in</a>
+      <clerk-user-button *clerkSignedIn />
+    </header>
+    <router-outlet />
+  `,
+})
+export class AppComponent {}
+```
+
+Add a catch-all route for the sign-in page (covered in full under [Authentication]({% link authentication.md %})):
+
+```ts
+// src/app/app.routes.ts
+import { Routes } from '@angular/router';
+import { catchAllRoute } from 'ngx-clerk';
+
+export const routes: Routes = [
+  {
+    matcher: catchAllRoute('sign-in'),
+    loadComponent: () => import('./sign-in.component').then((m) => m.SignInComponent),
+  },
+];
+```
+
+## Run your app
+
+```bash
+ng serve
+```
+
+Open `http://localhost:4200`. You'll see the **Sign in** link; once you've signed in, the user button appears in its place.
+
+## Create your first user
+
+1. Run your app and click **Sign in**.
+2. Complete the sign-up flow in the Clerk UI.
+3. Find the new user in the [Clerk Dashboard](https://dashboard.clerk.com/) under **Users**.
+
+## Next steps
+
+- [Authentication]({% link authentication.md %}) — sign-in/up components, auth buttons, and control-flow directives
+- [Protecting routes]({% link protecting-routes.md %}) — route guards and the `*clerkProtect` directive
+- [Session tokens]({% link session-tokens.md %}) — authenticate your backend with `getToken()`
+- [Reading auth state]({% link reading-auth-state.md %}) — access the current user, session, and organization

--- a/website/reading-auth-state.md
+++ b/website/reading-auth-state.md
@@ -1,0 +1,61 @@
+---
+title: Reading auth state
+nav_order: 6
+---
+
+# Reading auth state
+
+`ClerkService` exposes Clerk's state as Angular signals. Inject it anywhere:
+
+```ts
+import { Component, inject } from '@angular/core';
+import { ClerkService } from 'ngx-clerk';
+
+@Component({
+  selector: 'app-profile',
+  template: `<!-- … -->`,
+})
+export class ProfileComponent {
+  protected readonly clerk = inject(ClerkService);
+}
+```
+
+Read the signals in a template:
+
+{% raw %}
+```html
+@if (clerk.user(); as user) {
+  <p>Hello {{ user.firstName }}</p>
+}
+```
+{% endraw %}
+
+## Signals
+
+| Signal | Description |
+| --- | --- |
+| `clerk()` | the Clerk instance, or `null` until loaded |
+| `user()` | the current `UserResource`, or `null` |
+| `session()` | the active session, or `null` |
+| `organization()` | the active organization, or `null` |
+| `isLoaded()` | whether Clerk has finished loading |
+| `isSignedIn()` | whether a user is signed in |
+| `userId()`, `sessionId()`, `orgId()` | the corresponding IDs, or `null` |
+| `orgRole()`, `orgSlug()` | the user's role in, and slug of, the active organization |
+| `sessionClaims()`, `actor()` | the active session's JWT claims and actor |
+| `signIn()`, `signUp()` | the active sign-in / sign-up attempt resources |
+| `sessions()` | every session registered on the device |
+| `membership()` | the user's membership in the active organization |
+
+## Methods
+
+| Method | Description |
+| --- | --- |
+| `has(params)` | check a role / permission / feature / plan |
+| `getToken(options?)` | get the current session JWT |
+| `setActive(params)` | switch the active session or organization |
+| `handleRedirectCallback(params?)` | complete an OAuth/SSO redirect |
+| `signOut(options?)` | sign the current user out |
+| `redirectToSignIn()`, `redirectToSignUp()` | navigate to the Clerk sign-in/up pages |
+| `openSignIn()`, `openUserProfile()`, … | open the modal UIs (with matching `close*` helpers) |
+| `updateClerkOptions(options)` | update appearance/localization at runtime |

--- a/website/session-tokens.md
+++ b/website/session-tokens.md
@@ -1,0 +1,54 @@
+---
+title: Session tokens
+nav_order: 5
+---
+
+# Session tokens
+
+Call `ClerkService.getToken()` to retrieve the current session JWT and authenticate requests to your backend. It resolves to `null` when no user is signed in.
+
+```ts
+const token = await clerk.getToken();
+```
+
+You can also request a token for a specific [JWT template](https://clerk.com/docs/backend-requests/making/jwt-templates):
+
+```ts
+const token = await clerk.getToken({ template: 'my-template' });
+```
+
+## In an HTTP interceptor
+
+Attach the token to outgoing requests with a functional interceptor:
+
+```ts
+// src/app/auth.interceptor.ts
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { from, switchMap } from 'rxjs';
+import { ClerkService } from 'ngx-clerk';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const clerk = inject(ClerkService);
+  return from(clerk.getToken()).pipe(
+    switchMap((token) =>
+      next(token ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } }) : req),
+    ),
+  );
+};
+```
+
+Register it in your app config:
+
+```ts
+// src/app/app.config.ts
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { authInterceptor } from './auth.interceptor';
+
+export const appConfig = {
+  providers: [
+    provideHttpClient(withInterceptors([authInterceptor])),
+    // …provideClerk, provideRouter, etc.
+  ],
+};
+```


### PR DESCRIPTION
Adds a documentation site for ngx-clerk, deployed to GitHub Pages.

## What's included

- A Jekyll site (just-the-docs theme) under `website/`, authored entirely in markdown.
- Pages: **Quickstart** (a step-by-step getting-started flow), **Authentication**, **Protecting routes**, **Session tokens**, and **Reading auth state** — each with copy-paste examples.
- A GitHub Actions workflow (`.github/workflows/docs.yml`) that builds the site and deploys it to GitHub Pages on push to `main`. The build also runs on pull requests (without deploying) so broken builds are caught before merge.

## One-time setup

To enable publishing, set **Settings → Pages → Build and deployment → Source** to **GitHub Actions**. The site will then be available at `https://anagstef.github.io/ngx-clerk/`.
