### PR TITLE
fix(docs): Apply the theme layout to all pages

### DIFF
--- a/website/_config.yml
+++ b/website/_config.yml
@@ -10,6 +10,14 @@ color_scheme: dark
 search_enabled: true
 heading_anchors: true
 
+# Pages don't set a layout in front matter; without this, Jekyll emits bare
+# HTML fragments with no <head> (and therefore no theme CSS).
+defaults:
+  - scope:
+      path: ''
+    values:
+      layout: default
+
 aux_links:
   GitHub:
     - https://github.com/anagstef/ngx-clerk


### PR DESCRIPTION
## Problem

The deployed docs site rendered as unstyled HTML. No page declares a `layout:` in its front matter and `_config.yml` had no `defaults` block, so Jekyll emitted bare HTML fragments — no `<head>`, so the theme's CSS (which deploys fine) was never linked.

## Solution

A config-level `defaults` block assigns just-the-docs' `default` layout to every page, covering all 12 committed pages, the build-generated migration page, and any future page.