### PR TITLE
fix(release): Build before semantic-release verifies the npm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,10 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # @semantic-release/npm verifies pkgRoot's package.json before anything
+      # runs; the prepare step re-stamps the version and rebuilds.
+      - run: pnpm build
+
       - name: Release
         run: npx semantic-release
         env:


### PR DESCRIPTION
## Problem

The first real Release run failed at `verifyConditions`: `@semantic-release/npm` requires `pkgRoot` (`dist/ngx-clerk`) to contain a `package.json` before anything executes, but `dist/` is only produced later by the prepare step's build. Latent since the release config was added — no real release had ever run.

## Solution

Run `pnpm build` in the workflow before `npx semantic-release`, so verification finds the built package. The prepare step still stamps the computed version and rebuilds, so the published artifact is unchanged.